### PR TITLE
Fix potential issue if tool description is none

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -106,7 +106,7 @@ def _format_tool(
         parameters=convert(tool.parameters, custom_serializer=custom_serializer),
     )
     tool_spec["description"] = (
-        tool.description if tool.description.strip() else "A callable function"
+        tool.description if tool.description is not None and tool.description.strip() else "A callable function"
     )
     return ChatCompletionFunctionToolParam(type="function", function=tool_spec)
 


### PR DESCRIPTION
If the tool description is none then .strip() will fail. This checks that so that if its none or .strip() is empty.

Noticed this while debugging other issues.