### PR TITLE
allow user to disable thinking

### DIFF
--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_PARALLEL_TOOL_CALLS,
     CONF_SERVER_NAME,
     CONF_STRIP_EMOJIS,
+    CONF_DISABLE_THINKING,
     CONF_TEMPERATURE,
     CONF_WEAVIATE_API_KEY,
     CONF_WEAVIATE_CLASS_NAME,
@@ -293,6 +294,10 @@ class ConversationFlowHandler(LocalAiSubentryFlowHandler):
             ): bool,
             vol.Optional(
                 CONF_STRIP_EMOJIS,
+                default=False,
+            ): bool,
+            vol.Optional(
+                CONF_DISABLE_THINKING,
                 default=False,
             ): bool,
             vol.Optional(

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -15,6 +15,7 @@ CONF_STRIP_EMOJIS = "strip_emojis"
 CONF_MAX_MESSAGE_HISTORY = "max_message_history"
 CONF_TEMPERATURE = "temperature"
 CONF_PARALLEL_TOOL_CALLS = "parallel_tool_calls"
+CONF_DISABLE_THINKING = "disable_thinking"
 
 CONF_CONTENT_INJECTION_METHOD_SYSTEM = "System"
 CONF_CONTENT_INJECTION_METHOD_ASSISTANT = "Assistant"

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -43,6 +43,7 @@ from .const import (
     CONF_MAX_MESSAGE_HISTORY,
     CONF_PARALLEL_TOOL_CALLS,
     CONF_STRIP_EMOJIS,
+    CONF_DISABLE_THINKING,
     CONF_TEMPERATURE,
     CONF_WEAVIATE_API_KEY,
     CONF_WEAVIATE_CLASS_NAME,
@@ -369,6 +370,7 @@ class LocalAiEntity(Entity):
         max_message_history = options.get(CONF_MAX_MESSAGE_HISTORY, 0)
         temperature = options.get(CONF_TEMPERATURE, 0.6)
         parallel_tool_calls = options.get(CONF_PARALLEL_TOOL_CALLS, True)
+        disable_thinking = options.get(CONF_DISABLE_THINKING)
 
         model_args = {
             "model": self.model,
@@ -477,6 +479,9 @@ class LocalAiEntity(Entity):
             model_args["tools"] = tools
 
         model_args["messages"] = messages
+
+        if disable_thinking:
+            model_args["extra_body"] = {"chat_template_kwargs":{"enable_thinking": False}}
 
         if structure:
             if TYPE_CHECKING:

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -71,6 +71,7 @@
             "prompt": "System Prompt",
             "llm_hass_api": "Tool Providers",
             "strip_emojis": "Strip emojis from response",
+            "disable_thinking": "Disable thinking",
             "suggested_value": "Suggested value",
             "temperature": "Temperature",
             "max_message_history": "Max message history size (0 for no limit)",
@@ -81,6 +82,7 @@
             "model": "The model to use for the conversation agent",
             "prompt": "Instruct how the LLM should respond. This can be a template",
             "parallel_tool_calls": "Allow the model to use multiple tools in a single turn",
+            "disable_thinking": "Only for LLMs with thinking capabilities (i.e. Deepseek, Nemotron)",
             "temperature": "Lower for more predictable responses, higher for more randomness",
             "content_injection_method": "The message role to insert dynamic content as. See the readme for details"
           },
@@ -107,6 +109,7 @@
             "prompt": "System Prompt",
             "llm_hass_api": "Tool Providers",
             "strip_emojis": "Strip emojis from response",
+            "disable_thinking": "Disable thinking",
             "suggested_value": "Suggested value",
             "temperature": "Temperature",
             "max_message_history": "Max message history size (0 for no limit)",
@@ -117,6 +120,7 @@
             "model": "The model to use for the conversation agent",
             "prompt": "Instruct how the LLM should respond. This can be a template",
             "parallel_tool_calls": "Allow the model to use multiple tools in a single turn",
+            "disable_thinking": "Only for LLMs with thinking capabilities (i.e. Deepseek, Nemotron)",
             "temperature": "Lower for more predictable responses, higher for more randomness",
             "content_injection_method": "The message role to insert dynamic content as. See the readme for details."
           },


### PR DESCRIPTION
Models with thinking capabilities (like Deepseek or Nemotron) can be instructed to switch such functionality off.

Answers become shallow, but response time drop drastically. This can be quite useful when using the model in HA.

GitHub: fixes skye-harris/hass_local_openai_llm#23