### PR TITLE
Set correct response format so LocalAI ImageGen works

### DIFF
--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -117,13 +117,14 @@ class LocalAITaskEntity(
             image_buffer = io.BytesIO(img_data)
             img = Image.open(image_buffer)
             width, height = img.size
+            mime_type = img.get_format_mimetype()
         except Exception as err:
             _LOGGER.error("Error decoding base64 image response: %s", err)
             raise HomeAssistantError(f"Error decoding image response: {err}") from err
 
         _LOGGER.debug(
             "Generated image details: mime_type=%s, width=%s, height=%s",
-            "image/png",
+            mime_type,
             width,
             height,
         )
@@ -131,7 +132,7 @@ class LocalAITaskEntity(
         return ai_task.GenImageTaskResult(
             image_data=img_data,
             conversation_id=chat_log.conversation_id,
-            mime_type="image/png",
+            mime_type=mime_type,
             width=width,
             height=height,
             model=self.model,

--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -147,7 +147,9 @@ class LocalAITaskEntity(
         _LOGGER.debug("Sending image generation request to API")
         try:
             response = await client.images.generate(
-                prompt=ai_task.instructions, model=self.model, output_format="png"
+                prompt=ai_task.instructions,
+                model=self.model,
+                response_format="b64_json",
             )
         except openai.OpenAIError as err:
             _LOGGER.error("Error requesting image response from API: %s", err)


### PR DESCRIPTION
LocalAI sends an image file location by default, needs the response format set to use b64.

Not 100% sure which services was used to create the original PR and if there needs to be some additional logic to know what to set