### PR TITLE
Pass conversation session ID for LLM proxy tracing

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -557,6 +557,14 @@ class LocalAiEntity(Entity):
             _LOGGER.debug(f"Chat template kwargs: {kwargs}")
             model_args["extra_body"] = {"chat_template_kwargs": kwargs}
 
+        # Pass conversation session ID via metadata for LLM proxy tracing (LiteLLM + Langfuse)
+        if user_input and hasattr(user_input, "conversation_id") and user_input.conversation_id:
+            if "extra_body" not in model_args:
+                model_args["extra_body"] = {}
+            model_args["extra_body"].setdefault("metadata", {})["session_id"] = (
+                user_input.conversation_id
+            )
+
         if structure:
             if TYPE_CHECKING:
                 assert structure_name is not None


### PR DESCRIPTION
Inject Home Assistant's `conversation_id` as a `session_id` in the OpenAI `extra_body` metadata field so LiteLLM can forward grouped session context to Langfuse. 

Helpful for analyzing multi-turn conversations.

<img width="645" height="310" alt="image" src="https://github.com/user-attachments/assets/2e88c0c7-8111-4187-8b97-754b38deea1f" />
