### PR TITLE
Add OpenRouter app attribution headers

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -434,6 +434,10 @@ class LocalAiEntity(Entity):
             "model": self.model,
             "temperature": temperature,
             "parallel_tool_calls": parallel_tool_calls,
+            "extra_headers": {
+                "HTTP-Referer": "https://github.com/skye-harris/hass_local_openai_llm",
+                "X-Title": "Home Assistant",
+            },
         }
 
         tools: list[ChatCompletionFunctionToolParam] | None = None


### PR DESCRIPTION
- Restores `HTTP-Referer` and `X-Title` headers to all API requests
- These were removed in a15c17a as "unnecessary" but are used by OpenRouter for app attribution
- Without them, the App shows as "Unknown" in the OpenRouter activity log rather than "Home Assistant"
- `HTTP-Referer` points to this repo instead of the upstream HA integration