### PR TITLE
Pass back reasoning content if available

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -222,6 +222,12 @@ async def _convert_content_to_chat_message(
                 )
                 for tool_call in content.tool_calls
             ]
+        # Reasoning models (e.g. DeepSeek) return reasoning_content in the response.
+        # The API requires this to be passed back on subsequent turns in the conversation.
+        if isinstance(content, conversation.AssistantContent) and getattr(
+            content, "thinking_content", None
+        ):
+            param["reasoning_content"] = content.thinking_content
         return param
     _LOGGER.warning("Could not convert message to Completions API: %s", content)
     return None


### PR DESCRIPTION
This fixes an issue when using the DeepSeek v4 models in conversation, where it would fail with:

```
Error code: 400 - {'error': {'message': 'The `reasoning_content` in the thinking mode must be passed back to the API.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
Traceback (most recent call last):
  File "/config/custom_components/local_openai/entity.py", line 600, in _async_handle_chat_log
    result_stream = await client.chat.completions.create(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        **model_args, stream=True
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/openai/resources/chat/completions/completions.py", line 2676, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
    ...<49 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/openai/_base_client.py", line 1884, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/openai/_base_client.py", line 1669, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': 'The `reasoning_content` in the thinking mode must be passed back to the API.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
```