### PR TITLE
Rename chat_template_kwargs field label from 'Name' to 'Key'

### DIFF
--- a/custom_components/local_openai/__init__.py
+++ b/custom_components/local_openai/__init__.py
@@ -13,11 +13,66 @@ from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.typing import ConfigType
 from openai import AsyncOpenAI, AuthenticationError, OpenAIError
 
-from .const import CONF_BASE_URL, DOMAIN, LOGGER
+from .const import (
+    CONF_CHAT_TEMPLATE_KWARGS,
+    CONF_CHAT_TEMPLATE_OPTS,
+    CONF_BASE_URL,
+    DOMAIN,
+    LOGGER,
+)
 
 PLATFORMS = [Platform.AI_TASK, Platform.CONVERSATION]
 
 type LocalAiConfigEntry = ConfigEntry[AsyncOpenAI]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry to new version."""
+    LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        entry.version,
+        entry.minor_version or 1,
+    )
+
+    if entry.version > 2:
+        # User has downgraded from a future version
+        return False
+
+    if entry.version == 1:
+        # Migrate conversation subentries: rename "Name" key to "Key" in chat_template_kwargs
+        for subentry in entry.subentries.values():
+            if subentry.subentry_type != "conversation":
+                continue
+
+            data = dict(subentry.data)
+            chat_template_opts = data.get(CONF_CHAT_TEMPLATE_OPTS, {})
+            chat_template_kwargs = chat_template_opts.get(CONF_CHAT_TEMPLATE_KWARGS, [])
+
+            migrated = False
+            new_kwargs = []
+            for item in chat_template_kwargs:
+                item_dict = dict(item)
+                if "Name" in item_dict and "Key" not in item_dict:
+                    item_dict["Key"] = item_dict.pop("Name")
+                    migrated = True
+                new_kwargs.append(item_dict)
+
+            if migrated:
+                data[CONF_CHAT_TEMPLATE_OPTS] = {
+                    **chat_template_opts,
+                    CONF_CHAT_TEMPLATE_KWARGS: new_kwargs,
+                }
+                hass.config_entries.async_update_subentry(
+                    entry,
+                    subentry,
+                    data=data,
+                )
+
+        # Bump config entry version to prevent re-running migration
+        hass.config_entries.async_update_entry(entry, version=2)
+
+    LOGGER.debug("Migration to configuration version %s successful", 2)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LocalAiConfigEntry) -> bool:

--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -98,7 +98,7 @@ def options_to_selections_dict(opts: dict) -> list[SelectOptionDict]:
 class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Local OpenAI LLM."""
 
-    VERSION = 1
+    VERSION = 2
 
     @classmethod
     @callback

--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -355,7 +355,7 @@ class ConversationFlowHandler(LocalAiSubentryFlowHandler):
                             config={
                                 "multiple": True,
                                 "fields": {
-                                    "Name": {
+                                    "Key": {
                                         "selector": {"text": None},
                                         "required": True,
                                     },

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -553,7 +553,7 @@ class LocalAiEntity(Entity):
 
         # Filter args without a name - they are marked as required in the schema but this isn't being enforced on the front-end
         chat_template_args = [
-            keypair for keypair in chat_template_args if keypair["Name"].strip()
+            keypair for keypair in chat_template_args if keypair["Key"].strip()
         ]
 
         # Additional args to be passed into extra_body:
@@ -563,9 +563,9 @@ class LocalAiEntity(Entity):
         if chat_template_args:
             kwargs = {}
             for keypair in chat_template_args:
-                if keypair["Name"]:
+                if keypair["Key"]:
                     # Our value is a template, so that non-string data types and more complex structures can be provided by the user
-                    kwargs[keypair["Name"]] = template.Template(
+                    kwargs[keypair["Key"]] = template.Template(
                         keypair["Value"],
                         self.hass,
                     ).async_render()


### PR DESCRIPTION
I wasted some time because I initially thought the "Name" field was just a cosmetic title, and that both key and value should go in the second field.  Hopefully being explicit that it is a key will help avoid confusion.