### PR TITLE
Include usage in response

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -602,7 +602,12 @@ class LocalAiEntity(Entity):
         for _iteration in range(MAX_TOOL_ITERATIONS):
             try:
                 result_stream = await client.chat.completions.create(
-                    **model_args, stream=True
+                    **model_args,
+                    stream=True,
+                    stream_options={
+                        # Include usage statistics (token counts) in the final chunk of streamed responses
+                        "include_usage": True
+                    }
                 )
             except openai.OpenAIError as err:
                 _LOGGER.exception(err)


### PR DESCRIPTION
I route all LLM requests through a proxy, which tracks token usage. I noticed the token counts missing from this plugin, this fixed it. With this param set, llama.cpp (and others) will include usage statistics in API responses. This can be used for auditing token costs, or even later can be used in HomeAssistant dashboards or chat windows

See https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events

Note: pi coding agent sets this param [here](https://github.com/earendil-works/pi/blob/e25415dd5f0b68fe084d53333dc4af1b9adf2e49/packages/ai/src/providers/openai-completions.ts#L516) 