### PR TITLE
Add KW arg support for AI Task

### DIFF
--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -560,6 +560,30 @@ class AITaskDataFlowHandler(LocalAiSubentryFlowHandler):
                         }
                     ),
                 ),
+                vol.Required(CONF_CHAT_TEMPLATE_OPTS): section(
+                    options=SectionConfig(collapsed=True),
+                    schema=vol.Schema(
+                        schema={
+                            vol.Required(
+                                CONF_CHAT_TEMPLATE_KWARGS, default=[]
+                            ): ObjectSelector(
+                                config={
+                                    "multiple": True,
+                                    "fields": {
+                                        "Key": {
+                                            "selector": {"text": None},
+                                            "required": True,
+                                        },
+                                        "Value": {
+                                            "selector": {"template": None},
+                                            "required": True,
+                                        },
+                                    },
+                                }
+                            ),
+                        }
+                    ),
+                ),
             }
         )
 

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -200,6 +200,12 @@
               "data_description": {
                 "parallel_tool_calls": "Allow the model to use multiple tools in a single turn"
               }
+            },
+            "chat_template_opts": {
+              "name": "Chat Template Arguments",
+              "data": {
+                "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
+              }
             }
           }
         },
@@ -219,6 +225,12 @@
               },
               "data_description": {
                 "parallel_tool_calls": "Allow the model to use multiple tools in a single turn"
+              }
+            },
+            "chat_template_opts": {
+              "name": "Chat Template Arguments",
+              "data": {
+                "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
               }
             }
           }


### PR DESCRIPTION
This PR adds support for defining KW args for the LLM AI Task type. This is useful for the general reasons that it is useful for the conversation, and also specifically because it makes it easy to create a "fast" and a "slow" AI task without and with thinking, so that they can be employed to do various tasks.