### PR TITLE
Bugfix thinking content parser (reasoning_content vs reasoning)

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -346,7 +346,8 @@ class LocalAiEntity(Entity):
                         )
 
             # Handle reasoning_content field (used by reasoning models via OpenAI-compatible APIs)
-            reasoning_content = getattr(delta, "reasoning_content", None)
+            # Naming for this field varies. See https://github.com/vllm-project/vllm/issues/27755
+            reasoning_content = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_content:
                 if _SUPPORTS_THINKING:
                     chunk["thinking_content"] = reasoning_content


### PR DESCRIPTION
I've noticed that the thinking/reasoning content is not shown in HA, although support has already been added in https://github.com/skye-harris/hass_local_openai_llm/pull/51. Looks like (at least) vLLM has renamed the associated key from `reasoning_content` to `reasoning` (see https://github.com/vllm-project/vllm/issues/27755).

I tested the change and can confirm that the reasoning content is now correctly shown in HA.