### PR TITLE
Add server-type configurations, DeepSeek reasoning options

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,34 +7,20 @@ select = ["ALL"]
 
 ignore = [
     "ARG001", # "unused-argument"
-    "ARG004",
-#    "ANN101", # Missing type annotation for `self` in method
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-    "D203",   # no-blank-line-before-class (incompatible with formatter)
-    "D212",   # multi-line-summary-first-line (incompatible with formatter)
+    "D203", # no-blank-line-before-class (incompatible with formatter)
+    "D212", # multi-line-summary-first-line (incompatible with formatter)
     "COM812", # incompatible with formatter
-    "ISC001", # incompatible with formatter
 
     # Temporary exceptions for Ruff implementation
     "PERF401", # manual-list-comprehension
     "EXE002",
     "PLR0912",
-    "DTZ005",
-    "PLR2004",
-    "E722",
-    "F821",
     "E501",
     "PLR0915",
-    "FBT002",
-    "PLR0913",
-    "ANN001",
-    "SIM102",
-    "S105",
     "ARG002",
     "BLE001",
-    "PERF402",
-    "S101",
-    "ANN201",
+    "FBT001",
 ]
 
 [lint.flake8-pytest-style]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Ollama
 - OpenRouter
 - Scaleway
+- DeepSeek
 
 **This integration has been forked from Home Assistants OpenRouter integration, with the following changes:**
 
@@ -63,28 +64,46 @@ After installation, configure the integration through Home Assistant's UI:
 3. Search for `Local OpenAI LLM`.
 4. Follow the setup wizard to configure your desired services.
 
+---
+
 ### Configuration Notes
 
 - The Server URL must be a fully qualified URL pointing to an OpenAI-compatible API.
-    - This typically ends with `/v1` but may differ depending on your server configuration.
-- If you have the `Extended OpenAI Conversation` integration installed, this has a dependency of an older version of the OpenAI client library.
-    - It is strongly recommended this be uninstalled to ensure that HACS installs the correct OpenAI client library.
+  - This typically ends with `/v1` but may differ depending on your server configuration.
+- A Server Type configuration can be set to expose some additional options for different inference servers and providers, where they have been implemented.
 - Assist requires a fairly lengthy context for tooling and entity definitions.
-    - It is strongly recommended to use _at least_ 8k context size and to limit history length to avoid context overflow issues.
-    - This is not configurable through OpenAI-compatible APIs, and needs to be configured with the inference server directly.
+  - It is strongly recommended to use _at least_ 10k context size and to limit history length and exposed entities to avoid context overflow issues.
+  - This is not configurable through OpenAI-compatible APIs, and needs to be configured with the inference server directly.
 - Tool calling must be enabled in your inference engine, eg:
-    - **vLLM**: https://docs.vllm.ai/en/latest/features/tool_calling/
-    - **llama.cpp**: https://github.com/ggml-org/llama.cpp/blob/master/docs/function-calling.md
+  - **vLLM**: https://docs.vllm.ai/en/latest/features/tool_calling/
+  - **llama.cpp**: https://github.com/ggml-org/llama.cpp/blob/master/docs/function-calling.md
 - Parallel tool calling requires support from both your model and inference server.
-    - In some cases, control of this is handled by the server directly, in which case toggling this will not have any result.
+  - In some cases, control of this is handled by the server directly, in which case toggling this will not have any result.
 - Chat Template Arguments allow you to provide custom arguments to your model
-    - Arguments are supplied as key/value pairs and provided to the `chat_template_kwargs` request parameter
-    - Values support Jinja2 templates, in order to provide non-string and more complex data structures
-    - Arguments differ per model, and not all models make use of user-provided arguments
-    - See your models documentation for what arguments are available to be used
+  - Arguments are supplied as key/value pairs and provided to the `chat_template_kwargs` request parameter
+  - Values support Jinja2 templates, in order to provide non-string and more complex data structures
+  - Arguments differ per model, and not all models make use of user-provided arguments
+  - See your models documentation for what arguments are available to be used
 - AI Task entities can be configured for Text and/or Image generation capabilities
-    - This capability uses the [Images API](https://developers.openai.com/api/reference/resources/images) spec and requires support from your chosen image generation server
-    - Support has been developed and tested with [StableDiffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)
+  - This capability uses the [Images API](https://developers.openai.com/api/reference/resources/images) spec and requires support from your chosen image generation server
+  - Support has been developed and tested with [StableDiffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)
+
+---
+
+### DeepSeek Cloud Configuration
+
+#### Reasoning Effort
+
+When the server type is set to *DeepSeek Cloud*, both conversation and AI task agents show a new **DeepSeek Configuration** section with a **Reasoning Effort** option.
+This option controls whether thinking is enabled, and what level of reasoning to perform on the request.
+
+- **Disabled** (default) — no thinking tokens.
+- **High** — enables thinking with standard reasoning effort.
+- **Max** — enables thinking with maximum reasoning effort.
+
+When enabled, thinking content returned by the model is also fed back into the conversation as reasoning content on supported Home Assistant versions (2026.4+).
+
+---
 
 ### Experimental: Date/Time Context Injection Role
 
@@ -98,24 +117,27 @@ To this end I have provided a number of options so that users can try them out a
 The available options are:
 
 #### <u>Tool Result</u>:
+
 The date and time are inserted as a `Tool Call Result` message to the model, before the current user message.
 
 As long as the model does not reject it, this is the recommended method to use and produces the most reliable results during testing.
 
 #### <u>Assistant</u>:
+
 The date and time are inserted as an additional `Assistant` message to the model, before the current user message.
 
 In cases where the `Tool Call Result` role method does not work for a model, this is the next recommended to test with.
 
 #### <u>User</u>:
+
 The date and time are inserted as an additional `User` message to the model, before the current user message.
 
 Recommended only where neither the `System` nor `Assistant` injection methods work for the model, but may not produce desirable results.
 Some models have been known to repeat the date/time back to the user without request.
 
 #### <u>Disabled (no selection)</u>:
-If your model simply refuses to work well with any method, simply remove the value from the configuration option to disable this again.
 
+If your model simply refuses to work well with any method, simply remove the value from the configuration option to disable this again.
 
 ## Experimental: Retrieval Augmented Generation (RAG) with Weaviate
 
@@ -127,6 +149,8 @@ Once configured, user messages to the Agent will be queried against the Weaviate
 This is not a general-purpose "memory" for the Agent: content is only provided to the Agent if it matches on the current user input message to the model.
 
 See the [Weaviate documentation](https://docs.weaviate.io/weaviate) for further information on Weaviate.
+
+---
 
 ### Weaviate Configuration
 
@@ -176,11 +200,15 @@ _This is not a general-purpose Weaviate management tool, rather it is purpose-bu
     - GPT-OSS-120B on Scaleway.
 - A service action, `local_openai.add_to_weaviate`, can be used from within Home Assistant to add content to the database.
 
+---
+
 ## Web Search & Additional Tools
 
 Looking to add some more functionality to your Home Assistant conversation agent, such as web and localised business/location search? Check out my [Tools for Assist](https://github.com/skye-harris/llm_intents) integration here!
 
 These tools exist as a separate integration for compatibility across the wider Home Assistant Conversation ecosystem.
+
+---
 
 ## Acknowledgements
 

--- a/custom_components/local_openai/__init__.py
+++ b/custom_components/local_openai/__init__.py
@@ -2,21 +2,25 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import voluptuous as vol
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import service
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.typing import ConfigType
 from openai import AsyncOpenAI, AuthenticationError, OpenAIError
 
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.typing import ConfigType
+
 from .const import (
+    CONF_BASE_URL,
     CONF_CHAT_TEMPLATE_KWARGS,
     CONF_CHAT_TEMPLATE_OPTS,
-    CONF_BASE_URL,
     DOMAIN,
     LOGGER,
 )
@@ -34,7 +38,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.minor_version or 1,
     )
 
-    if entry.version > 2:
+    if entry.version > 2:  # noqa: PLR2004
         # User has downgraded from a future version
         return False
 
@@ -91,7 +95,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LocalAiConfigEntry) -> b
             break
     except AuthenticationError as err:
         LOGGER.error("Invalid API key: %s", err)
-        raise ConfigEntryError("Invalid API key") from err
+        msg = "Invalid API key"
+        raise ConfigEntryError(msg) from err
     except OpenAIError as err:
         raise ConfigEntryNotReady(err) from err
 
@@ -133,7 +138,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def upsert_data_in_weaviate(entity, service_call):
+async def upsert_data_in_weaviate(entity, service_call) -> None:  # noqa: ANN001
     """Service action to add content to Weaviate."""
     await entity.upsert_data_in_weaviate(
         query=service_call.data.get("query"),

--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -7,16 +7,14 @@ import io
 import logging
 import re
 from json import JSONDecodeError
+from typing import TYPE_CHECKING
 
 import openai
 from homeassistant.components import ai_task, conversation
 from homeassistant.components.conversation import SystemContent
-from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_LLM_HASS_API
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import llm
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.llm import async_get_api, selector_serializer
 from homeassistant.util.json import json_loads
 from PIL import Image
@@ -27,10 +25,33 @@ from .const import (
     CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
     CONF_AI_TASK_TOOLS_SECTION,
     CONF_PARALLEL_TOOL_CALLS,
+    CONF_SERVER_TYPE,
+    SERVER_TYPE_DEEPSEEK,
+    SERVER_TYPE_GENERIC,
+    SERVER_TYPE_LLAMACPP,
 )
 from .entity import LocalAiEntity
 
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigSubentry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_ai_task_entity(
+    server_type: str,
+) -> type[LocalAITaskEntity]:
+    if getattr(_get_ai_task_entity, "entity_map", None) is None:
+        from .entities.deepseek import DeepSeekAITaskEntity  # noqa: PLC0415
+        from .entities.llama_cpp import LlamaCppAITaskEntity  # noqa: PLC0415
+
+        _get_ai_task_entity.entity_map = {
+            SERVER_TYPE_DEEPSEEK: DeepSeekAITaskEntity,
+            SERVER_TYPE_LLAMACPP: LlamaCppAITaskEntity,
+        }
+    return _get_ai_task_entity.entity_map.get(server_type, LocalAITaskEntity)
 
 
 async def async_setup_entry(
@@ -39,12 +60,15 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up AI Task entities."""
+    entity_cls = _get_ai_task_entity(
+        config_entry.data.get(CONF_SERVER_TYPE, SERVER_TYPE_GENERIC),
+    )
     for subentry in config_entry.subentries.values():
         if subentry.subentry_type != "ai_task_data":
             continue
 
         async_add_entities(
-            [LocalAITaskEntity(config_entry, subentry)],
+            [entity_cls(config_entry, subentry)],
             config_subentry_id=subentry.subentry_id,
         )
 
@@ -63,13 +87,17 @@ class LocalAITaskEntity(
     )
 
     def __init__(
-        self, config_entry: LocalAiConfigEntry, subentry: ConfigSubentry
+        self,
+        config_entry: LocalAiConfigEntry,
+        subentry: ConfigSubentry,
     ) -> None:
+        """Initialize the AI Task entity."""
         ai_task.AITaskEntity.__init__(self)
         LocalAiEntity.__init__(self, config_entry, subentry)
 
         supported_attributes = self.subentry.data.get(
-            CONF_AI_TASK_SUPPORTED_ATTRIBUTES, ["generate_data"]
+            CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
+            ["generate_data"],
         )
         attributes = 0
         for attr in supported_attributes:
@@ -99,15 +127,13 @@ class LocalAITaskEntity(
                 device_id=None,
             )
             apis = await async_get_api(self.hass, llm_apis, llm_context)
-            apis.custom_serializer = (
-                apis.custom_serializer
-                if apis.custom_serializer
-                else selector_serializer
-            )
+            apis.custom_serializer = apis.custom_serializer or selector_serializer
             chat_log.llm_api = apis
             api_prompt = f"\n\n{apis.api_prompt.strip()}\n\nCurrent time"
             system_prompt = re.sub(
-                "\nCurrent time", api_prompt, chat_log.content[0].content
+                "\nCurrent time",
+                api_prompt,
+                chat_log.content[0].content,
             )
             chat_log.content[0] = SystemContent(content=system_prompt)
 
@@ -119,9 +145,8 @@ class LocalAITaskEntity(
         )
 
         if not isinstance(chat_log.content[-1], conversation.AssistantContent):
-            raise HomeAssistantError(
-                "Last content in chat log is not an AssistantContent"
-            )
+            msg = "Last content in chat log is not an AssistantContent"
+            raise HomeAssistantError(msg)
 
         text = chat_log.content[-1].content or ""
 
@@ -133,7 +158,8 @@ class LocalAITaskEntity(
         try:
             data = json_loads(text)
         except JSONDecodeError as err:
-            raise HomeAssistantError("Error with structured response") from err
+            msg = "Error with structured response"
+            raise HomeAssistantError(msg) from err
 
         return ai_task.GenDataTaskResult(
             conversation_id=chat_log.conversation_id,
@@ -159,8 +185,9 @@ class LocalAITaskEntity(
             width, height = img.size
             mime_type = img.get_format_mimetype()
         except Exception as err:
-            _LOGGER.error("Error decoding base64 image response: %s", err)
-            raise HomeAssistantError(f"Error decoding image response: {err}") from err
+            _LOGGER.exception("Error decoding base64 image response")
+            msg = f"Error decoding image response: {err}"
+            raise HomeAssistantError(msg) from err
 
         _LOGGER.debug(
             "Generated image details: mime_type=%s, width=%s, height=%s",
@@ -181,21 +208,21 @@ class LocalAITaskEntity(
     async def _async_handle_image_response(
         self,
         ai_task: ai_task.GenImageTask,
-    ):
+    ) -> openai.types.Image:
         """Generate an image response using the Images API."""
         client = self.entry.runtime_data
         attachments = ai_task.attachments or []
 
         for attachment in attachments:
             if not attachment.mime_type.startswith("image/"):
-                raise HomeAssistantError(
-                    f"Unsupported attachment type for image generation: {attachment.mime_type}"
-                )
+                msg = f"Unsupported attachment type for image generation: {attachment.mime_type}"
+                raise HomeAssistantError(msg)
 
         _LOGGER.debug("Sending image generation request to API")
         try:
             if attachments:
-                def read_files():
+
+                def read_files() -> list[tuple[str, bytes, str]]:
                     return [
                         (a.path.name, a.path.read_bytes(), a.mime_type)
                         for a in attachments
@@ -217,11 +244,13 @@ class LocalAITaskEntity(
                     response_format="b64_json",
                 )
         except openai.OpenAIError as err:
-            _LOGGER.error("Error requesting image response from API: %s", err)
-            raise HomeAssistantError(f"Error talking to API: {err}") from err
+            _LOGGER.exception("Error requesting image response from API")
+            msg = f"Error talking to API: {err}"
+            raise HomeAssistantError(msg) from err
 
         if len(response.data) == 0:
             _LOGGER.debug("No image received from API")
-            raise HomeAssistantError("No image was returned by the API")
+            msg = "No image was returned by the API"
+            raise HomeAssistantError(msg)
 
         return response.data[0]

--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -31,6 +31,10 @@ from homeassistant.helpers.selector import (
 )
 from openai import AsyncOpenAI, OpenAIError
 
+from custom_components.local_openai.entities.deepseek import (
+    get_conversation_config_schema as _deepseek_conversation_schema,
+)
+
 from .const import (
     CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
     CONF_AI_TASK_TOOLS_SECTION,
@@ -39,11 +43,18 @@ from .const import (
     CONF_CHAT_TEMPLATE_OPTS,
     CONF_CONTENT_INJECTION_METHOD,
     CONF_CONTENT_INJECTION_METHODS,
+    CONF_DEEPSEEK_CONFIG,
+    CONF_GENERIC_CONFIG,
+    CONF_LLAMACPP_CONFIG,
     CONF_MAX_MESSAGE_HISTORY,
     CONF_PARALLEL_TOOL_CALLS,
+    CONF_PASS_SESSION_ID,
     CONF_SERVER_NAME,
+    CONF_SERVER_OPTIONS,
+    CONF_SERVER_TYPE,
     CONF_STRIP_EMOJIS,
     CONF_TEMPERATURE,
+    CONF_VLLM_CONFIG,
     CONF_WEAVIATE_API_KEY,
     CONF_WEAVIATE_CLASS_NAME,
     CONF_WEAVIATE_DEFAULT_CLASS_NAME,
@@ -56,16 +67,21 @@ from .const import (
     CONF_WEAVIATE_MAX_RESULTS_MAX,
     CONF_WEAVIATE_OPTIONS,
     CONF_WEAVIATE_THRESHOLD,
-    CONF_PASS_SESSION_ID,
-    CONF_SERVER_OPTIONS,
     DOMAIN,
     LOGGER,
     RECOMMENDED_CONVERSATION_OPTIONS,
+    SERVER_TYPE_DEEPSEEK,
+    SERVER_TYPE_GENERIC,
+    SERVER_TYPE_LLAMACPP,
+    SERVER_TYPE_OPTIONS,
+    SERVER_TYPE_VLLM,
 )
 from .weaviate import WeaviateClient, WeaviateError
 
 
-async def prepare_weaviate_class(hass: HomeAssistant, weaviate_opts: dict[str, Any]):
+async def prepare_weaviate_class(
+    hass: HomeAssistant, weaviate_opts: dict[str, Any]
+) -> None:
     """Prepare our object class."""
     host = weaviate_opts.get(CONF_WEAVIATE_HOST)
     if not host:
@@ -95,6 +111,32 @@ def options_to_selections_dict(opts: dict) -> list[SelectOptionDict]:
     return [SelectOptionDict(value=key, label=opts[key]) for key in opts]
 
 
+def _get_conversation_config_schema(server_type: str) -> dict:
+    """Get the DeepSeek config for Conversation Agent entities."""
+    provider = {
+        SERVER_TYPE_DEEPSEEK: _deepseek_conversation_schema,
+    }.get(server_type)
+    return provider() if provider else {}
+
+
+def _get_ai_task_config_schema(server_type: str) -> dict:
+    """Get the DeepSeek config for AI Task entities."""
+    provider = {
+        SERVER_TYPE_DEEPSEEK: _deepseek_conversation_schema,
+    }.get(server_type)
+    return provider() if provider else {}
+
+
+def _get_server_type_config_key(server_type: str) -> str:
+    """Return the config key for the given server type."""
+    return {
+        SERVER_TYPE_GENERIC: CONF_GENERIC_CONFIG,
+        SERVER_TYPE_LLAMACPP: CONF_LLAMACPP_CONFIG,
+        SERVER_TYPE_VLLM: CONF_VLLM_CONFIG,
+        SERVER_TYPE_DEEPSEEK: CONF_DEEPSEEK_CONFIG,
+    }.get(server_type, CONF_GENERIC_CONFIG)
+
+
 class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Local OpenAI LLM."""
 
@@ -103,7 +145,7 @@ class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
     @classmethod
     @callback
     def async_get_supported_subentry_types(
-        cls, config_entry: ConfigEntry
+        cls, _config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this handler."""
         return {
@@ -112,7 +154,8 @@ class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
         }
 
     @staticmethod
-    def get_schema():
+    def get_schema() -> vol.Schema:
+        """Get the schema for the config flow form."""
         return vol.Schema(
             {
                 vol.Required(
@@ -121,6 +164,15 @@ class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): str,
                 vol.Required(CONF_BASE_URL, default=""): str,
                 vol.Optional(CONF_API_KEY, default=""): str,
+                vol.Required(
+                    CONF_SERVER_TYPE,
+                    default=SERVER_TYPE_GENERIC,
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        mode=SelectSelectorMode.DROPDOWN,
+                        options=options_to_selections_dict(SERVER_TYPE_OPTIONS),
+                    )
+                ),
                 vol.Optional(CONF_SERVER_OPTIONS): section(
                     schema=vol.Schema(
                         schema={
@@ -257,6 +309,7 @@ class LocalAiSubentryFlowHandler(ConfigSubentryFlow):
     """Handle subentry flow for Local OpenAI LLM."""
 
     def get_llm_apis(self) -> list[SelectOptionDict]:
+        """Get available LLM APIs as select options."""
         return [
             SelectOptionDict(
                 label=api.name,
@@ -275,7 +328,8 @@ class LocalAiSubentryFlowHandler(ConfigSubentryFlow):
 class ConversationFlowHandler(LocalAiSubentryFlowHandler):
     """Handle subentry flow."""
 
-    async def get_schema(self):
+    async def get_schema(self) -> vol.Schema:
+        """Get the schema for the conversation subentry form."""
         llm_apis = self.get_llm_apis()
         entry = self._get_entry()
         client = entry.runtime_data
@@ -370,6 +424,17 @@ class ConversationFlowHandler(LocalAiSubentryFlowHandler):
                 ),
             ),
         }
+
+        server_type = entry.data.get(CONF_SERVER_TYPE, SERVER_TYPE_GENERIC)
+        server_type_schema_fields = _get_conversation_config_schema(server_type)
+        if server_type_schema_fields:
+            schema = {
+                **schema,
+                vol.Required(_get_server_type_config_key(server_type)): section(
+                    options=SectionConfig(collapsed=True),
+                    schema=vol.Schema(schema=server_type_schema_fields),
+                ),
+            }
 
         if entry.data.get(CONF_WEAVIATE_OPTIONS, {}).get(CONF_WEAVIATE_HOST):
             schema = {
@@ -504,7 +569,8 @@ class ConversationFlowHandler(LocalAiSubentryFlowHandler):
 class AITaskDataFlowHandler(LocalAiSubentryFlowHandler):
     """Handle subentry flow."""
 
-    async def get_schema(self):
+    async def get_schema(self) -> vol.Schema:
+        """Get the schema for the AI task data subentry form."""
         try:
             client = self._get_entry().runtime_data
             response = await client.models.list()
@@ -524,68 +590,79 @@ class AITaskDataFlowHandler(LocalAiSubentryFlowHandler):
 
         llm_apis = self.get_llm_apis()
 
-        return vol.Schema(
-            {
-                vol.Required(
-                    CONF_MODEL,
-                ): SelectSelector(
-                    SelectSelectorConfig(options=downloaded_models, custom_value=True)
+        schema = {
+            vol.Required(
+                CONF_MODEL,
+            ): SelectSelector(
+                SelectSelectorConfig(options=downloaded_models, custom_value=True)
+            ),
+            vol.Required(
+                CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        {"value": "generate_data", "label": "Generate Data"},
+                        {"value": "generate_image", "label": "Generate Image"},
+                    ],
+                    multiple=True,
+                    mode=SelectSelectorMode.LIST,
+                )
+            ),
+            vol.Required(CONF_AI_TASK_TOOLS_SECTION): section(
+                options=SectionConfig(collapsed=True),
+                schema=vol.Schema(
+                    schema={
+                        vol.Optional(
+                            CONF_LLM_HASS_API,
+                            default=[],
+                        ): SelectSelector(
+                            SelectSelectorConfig(options=llm_apis, multiple=True)
+                        ),
+                        vol.Required(
+                            CONF_PARALLEL_TOOL_CALLS,
+                            default=True,
+                        ): bool,
+                    }
                 ),
-                vol.Required(
-                    CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        options=[
-                            {"value": "generate_data", "label": "Generate Data"},
-                            {"value": "generate_image", "label": "Generate Image"},
-                        ],
-                        multiple=True,
-                        mode=SelectSelectorMode.LIST,
-                    )
-                ),
-                vol.Required(CONF_AI_TASK_TOOLS_SECTION): section(
-                    options=SectionConfig(collapsed=True),
-                    schema=vol.Schema(
-                        schema={
-                            vol.Optional(
-                                CONF_LLM_HASS_API,
-                                default=[],
-                            ): SelectSelector(
-                                SelectSelectorConfig(options=llm_apis, multiple=True)
-                            ),
-                            vol.Required(
-                                CONF_PARALLEL_TOOL_CALLS,
-                                default=True,
-                            ): bool,
-                        }
-                    ),
-                ),
-                vol.Required(CONF_CHAT_TEMPLATE_OPTS): section(
-                    options=SectionConfig(collapsed=True),
-                    schema=vol.Schema(
-                        schema={
-                            vol.Required(
-                                CONF_CHAT_TEMPLATE_KWARGS, default=[]
-                            ): ObjectSelector(
-                                config={
-                                    "multiple": True,
-                                    "fields": {
-                                        "Key": {
-                                            "selector": {"text": None},
-                                            "required": True,
-                                        },
-                                        "Value": {
-                                            "selector": {"template": None},
-                                            "required": True,
-                                        },
+            ),
+            vol.Required(CONF_CHAT_TEMPLATE_OPTS): section(
+                options=SectionConfig(collapsed=True),
+                schema=vol.Schema(
+                    schema={
+                        vol.Required(
+                            CONF_CHAT_TEMPLATE_KWARGS, default=[]
+                        ): ObjectSelector(
+                            config={
+                                "multiple": True,
+                                "fields": {
+                                    "Key": {
+                                        "selector": {"text": None},
+                                        "required": True,
                                     },
-                                }
-                            ),
-                        }
-                    ),
+                                    "Value": {
+                                        "selector": {"template": None},
+                                        "required": True,
+                                    },
+                                },
+                            }
+                        ),
+                    }
+                ),
+            ),
+        }
+
+        server_type = self._get_entry().data.get(CONF_SERVER_TYPE, SERVER_TYPE_GENERIC)
+        server_type_schema_fields = _get_ai_task_config_schema(server_type)
+        if server_type_schema_fields:
+            schema = {
+                **schema,
+                vol.Required(_get_server_type_config_key(server_type)): section(
+                    options=SectionConfig(collapsed=True),
+                    schema=vol.Schema(schema=server_type_schema_fields),
                 ),
             }
-        )
+
+        return vol.Schema(schema)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -35,7 +35,7 @@ SERVER_TYPE_DEEPSEEK = "deepseek"
 SERVER_TYPE_OPTIONS = {
     SERVER_TYPE_GENERIC: "Generic OpenAI-Compatible",
     SERVER_TYPE_LLAMACPP: "llama.cpp",
-    SERVER_TYPE_VLLM: "vLLM",
+    # SERVER_TYPE_VLLM: "vLLM",
     SERVER_TYPE_DEEPSEEK: "DeepSeek Cloud",
 }
 

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -18,8 +18,26 @@ CONF_TEMPERATURE = "temperature"
 CONF_PARALLEL_TOOL_CALLS = "parallel_tool_calls"
 CONF_CHAT_TEMPLATE_OPTS = "chat_template_opts"
 CONF_CHAT_TEMPLATE_KWARGS = "chat_template_kwargs"
-CONF_PASS_SESSION_ID = "pass_session_id"
+CONF_PASS_SESSION_ID = "pass_session_id"  # noqa: S105
 CONF_SERVER_OPTIONS = "server_options"
+CONF_SERVER_TYPE = "server_type"
+CONF_GENERIC_CONFIG = "generic_config"
+CONF_LLAMACPP_CONFIG = "llamacpp_config"
+CONF_VLLM_CONFIG = "vllm_config"
+CONF_DEEPSEEK_CONFIG = "deepseek_config"
+CONF_DEEPSEEK_REASONING_EFFORT = "deepseek_reasoning_effort"
+
+SERVER_TYPE_GENERIC = "generic"
+SERVER_TYPE_LLAMACPP = "llama_cpp"
+SERVER_TYPE_VLLM = "vllm"
+SERVER_TYPE_DEEPSEEK = "deepseek"
+
+SERVER_TYPE_OPTIONS = {
+    SERVER_TYPE_GENERIC: "Generic OpenAI-Compatible",
+    SERVER_TYPE_LLAMACPP: "llama.cpp",
+    SERVER_TYPE_VLLM: "vLLM",
+    SERVER_TYPE_DEEPSEEK: "DeepSeek Cloud",
+}
 
 CONF_AI_TASK_SUPPORTED_ATTRIBUTES = "supported_attributes"
 CONF_AI_TASK_SUPPORTED_ATTRIBUTE_OPTIONS = {

--- a/custom_components/local_openai/conversation.py
+++ b/custom_components/local_openai/conversation.py
@@ -1,17 +1,45 @@
 """Conversation support for Local OpenAI LLM."""
 
-from typing import Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
 
 from homeassistant.components import conversation
-from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_LLM_HASS_API, CONF_PROMPT, MATCH_ALL
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import LocalAiConfigEntry
-from .const import CONF_PARALLEL_TOOL_CALLS, DOMAIN
+from .const import (
+    CONF_PARALLEL_TOOL_CALLS,
+    CONF_SERVER_TYPE,
+    DOMAIN,
+    SERVER_TYPE_DEEPSEEK,
+    SERVER_TYPE_GENERIC,
+    SERVER_TYPE_LLAMACPP,
+)
 from .entity import LocalAiEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigSubentry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+    from . import LocalAiConfigEntry
+
+
+def _get_conversation_entity(
+    server_type: str,
+) -> type[LocalAiConversationEntity]:
+    if getattr(_get_conversation_entity, "entity_map", None) is None:
+        from .entities.deepseek import DeepSeekConversationEntity  # noqa: PLC0415
+        from .entities.llama_cpp import LlamaCppConversationEntity  # noqa: PLC0415
+
+        _get_conversation_entity.entity_map = {
+            SERVER_TYPE_DEEPSEEK: DeepSeekConversationEntity,
+            SERVER_TYPE_LLAMACPP: LlamaCppConversationEntity,
+        }
+    return _get_conversation_entity.entity_map.get(
+        server_type, LocalAiConversationEntity
+    )
 
 
 async def async_setup_entry(
@@ -20,11 +48,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up conversation entities."""
+    entity_cls = _get_conversation_entity(
+        config_entry.data.get(CONF_SERVER_TYPE, SERVER_TYPE_GENERIC),
+    )
     for subentry_id, subentry in config_entry.subentries.items():
         if subentry.subentry_type != "conversation":
             continue
         async_add_entities(
-            [LocalAiConversationEntity(config_entry, subentry)],
+            [entity_cls(config_entry, subentry)],
             config_subentry_id=subentry_id,
         )
 

--- a/custom_components/local_openai/entities/__init__.py
+++ b/custom_components/local_openai/entities/__init__.py
@@ -1,0 +1,1 @@
+"""Server-type-specific entity implementations."""

--- a/custom_components/local_openai/entities/deepseek.py
+++ b/custom_components/local_openai/entities/deepseek.py
@@ -1,0 +1,104 @@
+"""Server-specific entities for DeepSeek Cloud."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.components import conversation
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from custom_components.local_openai.ai_task import LocalAITaskEntity
+from custom_components.local_openai.const import (
+    CONF_DEEPSEEK_CONFIG,
+    CONF_DEEPSEEK_REASONING_EFFORT,
+)
+from custom_components.local_openai.conversation import LocalAiConversationEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigSubentry
+    from openai.types.chat import ChatCompletionMessageParam
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_deepseek_schema() -> dict:
+    return {
+        vol.Optional(
+            CONF_DEEPSEEK_REASONING_EFFORT,
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(value="high", label="High"),
+                    SelectOptionDict(value="max", label="Max"),
+                ],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+
+
+def get_conversation_config_schema() -> dict:
+    """Return conversation config schema fields for DeepSeek."""
+    return _get_deepseek_schema()
+
+
+def _deepseek_extra_body_args(options: dict) -> dict:
+    opts = options.get(CONF_DEEPSEEK_CONFIG, {})
+    reasoning_effort = opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
+    if reasoning_effort:
+        return {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": reasoning_effort,
+        }
+    return {"thinking": {"type": "disabled"}}
+
+
+async def _deepseek_augment_content_message(
+    subentry: ConfigSubentry,
+    param: ChatCompletionMessageParam | None,
+    content: conversation.Content,
+) -> ChatCompletionMessageParam | None:
+    opts = subentry.data.get(CONF_DEEPSEEK_CONFIG, {})
+    _LOGGER.warning("DeepSeek inject reasoning context")
+
+    if (
+        opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
+        and isinstance(content, conversation.AssistantContent)
+        and hasattr(content, "thinking_content")
+        and content.thinking_content
+    ):
+        param["reasoning_content"] = content.thinking_content
+    return param
+
+
+class DeepSeekConversationEntity(LocalAiConversationEntity):
+    """Conversation agent for DeepSeek Cloud servers."""
+
+    def _get_extra_body_args(self, options: dict, server_options: dict) -> dict:
+        return _deepseek_extra_body_args(options)
+
+    async def _convert_content_to_chat_message(
+        self, content: conversation.Content
+    ) -> ChatCompletionMessageParam | None:
+        param = await super()._convert_content_to_chat_message(content)
+        return await _deepseek_augment_content_message(self.subentry, param, content)
+
+
+class DeepSeekAITaskEntity(LocalAITaskEntity):
+    """AI Task entity for DeepSeek Cloud servers."""
+
+    def _get_extra_body_args(self, options: dict, server_options: dict) -> dict:
+        return _deepseek_extra_body_args(options)
+
+    async def _convert_content_to_chat_message(
+        self, content: conversation.Content
+    ) -> ChatCompletionMessageParam | None:
+        param = await super()._convert_content_to_chat_message(content)
+        return await _deepseek_augment_content_message(self.subentry, param, content)

--- a/custom_components/local_openai/entities/deepseek.py
+++ b/custom_components/local_openai/entities/deepseek.py
@@ -66,7 +66,6 @@ async def _deepseek_augment_content_message(
     content: conversation.Content,
 ) -> ChatCompletionMessageParam | None:
     opts = subentry.data.get(CONF_DEEPSEEK_CONFIG, {})
-    _LOGGER.warning("DeepSeek inject reasoning context")
 
     if (
         opts.get(CONF_DEEPSEEK_REASONING_EFFORT)

--- a/custom_components/local_openai/entities/llama_cpp.py
+++ b/custom_components/local_openai/entities/llama_cpp.py
@@ -1,0 +1,12 @@
+"""Server-specific entities for llama.cpp."""
+
+from custom_components.local_openai.ai_task import LocalAITaskEntity
+from custom_components.local_openai.conversation import LocalAiConversationEntity
+
+
+class LlamaCppConversationEntity(LocalAiConversationEntity):
+    """Conversation agent for llama.cpp servers."""
+
+
+class LlamaCppAITaskEntity(LocalAITaskEntity):
+    """AI Task entity for llama.cpp servers."""

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -7,39 +7,31 @@ import base64
 import json
 import logging
 import uuid
-from collections.abc import AsyncGenerator, Callable
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 import demoji
 import openai
-import voluptuous as vol
 from homeassistant.components import conversation
-from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_MODEL
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import llm, template
 from homeassistant.helpers.entity import Entity
-from openai._streaming import AsyncStream
+from homeassistant.util import dt as dt_util
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
-    ChatCompletionChunk,
     ChatCompletionContentPartImageParam,
     ChatCompletionContentPartTextParam,
     ChatCompletionFunctionToolParam,
     ChatCompletionMessageFunctionToolCallParam,
-    ChatCompletionMessageParam,
     ChatCompletionSystemMessageParam,
     ChatCompletionToolMessageParam,
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import Function
 from openai.types.shared_params import FunctionDefinition, ResponseFormatJSONSchema
-from openai.types.shared_params.response_format_json_schema import JSONSchema
 from voluptuous_openapi import convert
 
-from . import LocalAiConfigEntry
 from .const import (
     CONF_CHAT_TEMPLATE_KWARGS,
     CONF_CHAT_TEMPLATE_OPTS,
@@ -66,6 +58,18 @@ from .const import (
     DOMAIN,
 )
 from .weaviate import WeaviateClient
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable
+    from pathlib import Path
+
+    import voluptuous as vol
+    from homeassistant.config_entries import ConfigSubentry
+    from openai._streaming import AsyncStream
+    from openai.types.chat import ChatCompletionChunk, ChatCompletionMessageParam
+    from openai.types.shared_params.response_format_json_schema import JSONSchema
+
+    from . import LocalAiConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,85 +152,9 @@ def _format_tool(
     return ChatCompletionFunctionToolParam(type="function", function=tool_spec)
 
 
-def b64_file(file_path):
+def b64_file(file_path: Path) -> str:
     """Retrieve the base64 encoded file contents."""
     return base64.b64encode(file_path.read_bytes()).decode("utf-8")
-
-
-async def _convert_content_to_chat_message(
-    content: conversation.Content,
-) -> ChatCompletionMessageParam | None:
-    """Convert any native chat message for this agent to the native format."""
-    if isinstance(content, conversation.ToolResultContent):
-
-        def log_and_str(value) -> str:
-            _LOGGER.warning(
-                f"Attempting string convertion of non-JSON-serialisable response content from LLM tool '{content.tool_name}': {value}"
-            )
-            return str(value)
-
-        return ChatCompletionToolMessageParam(
-            role="tool",
-            tool_call_id=content.tool_call_id,
-            content=json.dumps(content.tool_result, default=log_and_str),
-        )
-
-    role: Literal["user", "assistant", "system"] = content.role
-    if role == "system" and content.content:
-        return ChatCompletionSystemMessageParam(role="system", content=content.content)
-
-    if role == "user" and content.content:
-        messages = []
-
-        if content.attachments:
-            loop = asyncio.get_running_loop()
-            for attachment in content.attachments or ():
-                if not attachment.mime_type.startswith("image/"):
-                    raise HomeAssistantError(
-                        translation_domain=DOMAIN,
-                        translation_key="unsupported_attachment_type",
-                    )
-                base64_file = await loop.run_in_executor(
-                    None, b64_file, attachment.path
-                )
-                messages.append(
-                    ChatCompletionContentPartImageParam(
-                        type="image_url",
-                        image_url={
-                            "url": f"data:{attachment.mime_type};base64,{base64_file}",
-                            "detail": "auto",
-                        },
-                    )
-                )
-
-        messages.append(
-            ChatCompletionContentPartTextParam(type="text", text=content.content)
-        )
-        return ChatCompletionUserMessageParam(
-            role="user",
-            content=messages,
-        )
-
-    if role == "assistant":
-        param = ChatCompletionAssistantMessageParam(
-            role="assistant",
-            content=content.content,
-        )
-        if isinstance(content, conversation.AssistantContent) and content.tool_calls:
-            param["tool_calls"] = [
-                ChatCompletionMessageFunctionToolCallParam(
-                    type="function",
-                    id=tool_call.id,
-                    function=Function(
-                        arguments=json.dumps(tool_call.tool_args),
-                        name=tool_call.tool_name,
-                    ),
-                )
-                for tool_call in content.tool_calls
-            ]
-        return param
-    _LOGGER.warning("Could not convert message to Completions API: %s", content)
-    return None
 
 
 def _make_uuid(identifier: str) -> str:
@@ -250,6 +178,91 @@ class LocalAiEntity(Entity):
             entry_type=dr.DeviceEntryType.SERVICE,
         )
 
+    # noinspection PyMethodMayBeStatic
+    def _get_extra_body_args(self, options: dict, server_options: dict) -> dict:
+        return {}
+
+    async def _convert_content_to_chat_message(
+        self, content: conversation.Content
+    ) -> ChatCompletionMessageParam | None:
+        if isinstance(content, conversation.ToolResultContent):
+
+            def log_and_str(value: Any) -> str:
+                _LOGGER.warning(
+                    "Attempting string convertion of non-JSON-serialisable response content from LLM tool '%s': %s",
+                    content.tool_name,
+                    value,
+                )
+                return str(value)
+
+            return ChatCompletionToolMessageParam(
+                role="tool",
+                tool_call_id=content.tool_call_id,
+                content=json.dumps(content.tool_result, default=log_and_str),
+            )
+
+        role: Literal["user", "assistant", "system"] = content.role
+        if role == "system" and content.content:
+            return ChatCompletionSystemMessageParam(
+                role="system", content=content.content
+            )
+
+        if role == "user" and content.content:
+            messages = []
+
+            if content.attachments:
+                loop = asyncio.get_running_loop()
+                for attachment in content.attachments or ():
+                    if not attachment.mime_type.startswith("image/"):
+                        raise HomeAssistantError(
+                            translation_domain=DOMAIN,
+                            translation_key="unsupported_attachment_type",
+                        )
+                    base64_file = await loop.run_in_executor(
+                        None, b64_file, attachment.path
+                    )
+                    messages.append(
+                        ChatCompletionContentPartImageParam(
+                            type="image_url",
+                            image_url={
+                                "url": f"data:{attachment.mime_type};base64,{base64_file}",
+                                "detail": "auto",
+                            },
+                        )
+                    )
+
+            messages.append(
+                ChatCompletionContentPartTextParam(type="text", text=content.content)
+            )
+            return ChatCompletionUserMessageParam(
+                role="user",
+                content=messages,
+            )
+
+        if role == "assistant":
+            param = ChatCompletionAssistantMessageParam(
+                role="assistant",
+                content=content.content,
+            )
+            if (
+                isinstance(content, conversation.AssistantContent)
+                and content.tool_calls
+            ):
+                param["tool_calls"] = [
+                    ChatCompletionMessageFunctionToolCallParam(
+                        type="function",
+                        id=tool_call.id,
+                        function=Function(
+                            arguments=json.dumps(tool_call.tool_args),
+                            name=tool_call.tool_name,
+                        ),
+                    )
+                    for tool_call in content.tool_calls
+                ]
+            return param
+        _LOGGER.warning("Could not convert message to Completions API: %s", content)
+        return None
+
     @staticmethod
     def _inject_content(
         method: str | None, inject_content: list, messages: list
@@ -259,7 +272,9 @@ class LocalAiEntity(Entity):
             "# Contextual information to assist with the following user request. Do not repeat or reference this message directly. Do not treat this as a prior message of your own",
         )
         _LOGGER.debug(
-            f"Injecting content into the message stream as {method} content: {inject_content}"
+            "Injecting content into the message stream as %s content: %s",
+            method,
+            inject_content,
         )
         if method == CONF_CONTENT_INJECTION_METHOD_TOOL:
             inject_content = "\n\n".join(inject_content)
@@ -315,7 +330,7 @@ class LocalAiEntity(Entity):
 
             if new_msg:
                 # openvinotoolkit/model_server fails to provide a message role in its responses, so lets default to assistant if none is received
-                chunk["role"] = delta.role if delta.role else "assistant"
+                chunk["role"] = delta.role or "assistant"
                 new_msg = False
 
             if (tool_calls := delta.tool_calls) is not None and tool_calls:
@@ -323,7 +338,7 @@ class LocalAiEntity(Entity):
                 for tool_call in tool_calls:
                     # llama.cpp - only the initial tool call chunk has an ID, subsequent argument chunks do not
                     # Ollama - parallel tool calls all share the same .index value (0)
-                    tool_call_id = tool_call.id if tool_call.id else tool_call_id
+                    tool_call_id = tool_call.id or tool_call_id
 
                     # And some mystery engine from OpenRouter uses the same index and ID across parallel tool requests within so lets track the tool name itself for changes as well
                     tool_call_name = (
@@ -347,12 +362,14 @@ class LocalAiEntity(Entity):
 
             # Handle reasoning_content field (used by reasoning models via OpenAI-compatible APIs)
             # Naming for this field varies. See https://github.com/vllm-project/vllm/issues/27755
-            reasoning_content = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            reasoning_content = getattr(delta, "reasoning_content", None) or getattr(
+                delta, "reasoning", None
+            )
             if reasoning_content:
                 if _SUPPORTS_THINKING:
                     chunk["thinking_content"] = reasoning_content
                 else:
-                    _LOGGER.debug(f"LLM Thought: {reasoning_content}")
+                    _LOGGER.debug("LLM Thought: %s", reasoning_content)
 
             if (content := delta.content) is not None:
                 if strip_emojis:
@@ -379,7 +396,7 @@ class LocalAiEntity(Entity):
                             if before_close:
                                 chunk["thinking_content"] = before_close
                         elif pending_think.strip():
-                            _LOGGER.debug(f"LLM Thought: {pending_think}")
+                            _LOGGER.debug("LLM Thought: %s", pending_think)
 
                         pending_think = ""
                     else:
@@ -401,7 +418,7 @@ class LocalAiEntity(Entity):
                     if event.timings:
                         self.extra_state_attributes = {"timings": event.timings}
                 except Exception:
-                    pass
+                    _LOGGER.exception("Error retrieving timings")
 
                 if pending_tool_calls:
                     chunk["tool_calls"] = [
@@ -414,7 +431,7 @@ class LocalAiEntity(Entity):
                         )
                         for key, tool_call in pending_tool_calls.items()
                     ]
-                    _LOGGER.debug(f"Calling tools: {pending_tool_calls}")
+                    _LOGGER.debug("Calling tools: %s", pending_tool_calls)
 
             if (
                 seen_visible
@@ -430,6 +447,7 @@ class LocalAiEntity(Entity):
         structure_name: str | None = None,
         structure: vol.Schema | None = None,
         user_input: conversation.ConversationInput | None = None,
+        *,
         parallel_tool_calls: bool = False,
     ) -> None:
         """Generate an answer for the chat log."""
@@ -460,14 +478,14 @@ class LocalAiEntity(Entity):
             [
                 m
                 for content in chat_log.content
-                if (m := await _convert_content_to_chat_message(content))
+                if (m := await self._convert_content_to_chat_message(content))
             ],
             max_message_history,
         )
 
         # Home Assistant no longer injects the current date/time into the system prompt, for performance reasons (negatively impacts caching)
         # It's still useful context to have however, and we can inject this at the end of the message chain along with any RAG content queried
-        dt = datetime.now()
+        dt = dt_util.now()
         date_str = dt.strftime("%A %d %B, %Y")
         time_str = dt.strftime("%-I:%M %p")
 
@@ -508,22 +526,18 @@ class LocalAiEntity(Entity):
                     ),
                 )
 
-                _LOGGER.debug(f"Weaviate results: {results}")
+                _LOGGER.debug("Weaviate results: %s", results)
 
                 result_content = [
                     f"Query: {result.get('query').strip()}\nContent: {result.get('content').strip()}"
                     for result in results
                 ]
                 if result_content:
-                    # inject_content.append(
-                    #     f"# Retrieval Augmented Generation\nYou may use the following information to answer the user question, if appropriate.\nIgnore this if it does not relate to or answer the users query.\n\n{'\n'.join(result_content)}"
-                    # )
                     inject_content += result_content
-            except Exception as err:
-                _LOGGER.warning(
-                    "An unexpected exception occurred while processing RAG: %s", err
+            except Exception:
+                _LOGGER.exception(
+                    "An unexpected exception occurred while processing RAG"
                 )
-                _LOGGER.exception(err)
 
         # Inject any pending content into the current user message
         # We prepend to the last message to avoid creating consecutive user messages
@@ -583,9 +597,11 @@ class LocalAiEntity(Entity):
                 "session_id": user_input.conversation_id,
             }
 
+        extra_body_args |= self._get_extra_body_args(options, server_options)
+
         # Insert our extra_body args if we have any
         if extra_body_args:
-            _LOGGER.debug(f"Extra-body args: {extra_body_args}")
+            _LOGGER.debug("Extra-body args: %s", extra_body_args)
             model_args["extra_body"] = extra_body_args
 
         if structure:
@@ -606,8 +622,9 @@ class LocalAiEntity(Entity):
                     **model_args, stream=True
                 )
             except openai.OpenAIError as err:
-                _LOGGER.exception(err)
-                raise HomeAssistantError("Error talking to API") from err
+                _LOGGER.exception("Error talking to API")
+                msg = "Error talking to API"
+                raise HomeAssistantError(msg) from err
 
             try:
                 model_args["messages"].extend(
@@ -619,12 +636,13 @@ class LocalAiEntity(Entity):
                                 stream=result_stream, strip_emojis=strip_emojis
                             ),
                         )
-                        if (msg := await _convert_content_to_chat_message(content))
+                        if (msg := await self._convert_content_to_chat_message(content))
                     ]
                 )
             except Exception as err:
-                _LOGGER.exception(err)
-                raise HomeAssistantError("Error handling API response") from err
+                _LOGGER.exception("Error handling API response")
+                msg = "Error handling API response"
+                raise HomeAssistantError(msg) from err
 
             if not chat_log.unresponded_tool_results:
                 break
@@ -664,7 +682,7 @@ class LocalAiEntity(Entity):
 
     async def upsert_data_in_weaviate(
         self, query: str, content: str, identifier: str | None
-    ):
+    ) -> None:
         """Add or update a record in Weaviate."""
         options = self.subentry.data
         weaviate_opts = options.get(CONF_WEAVIATE_OPTIONS, {})
@@ -675,7 +693,8 @@ class LocalAiEntity(Entity):
         )
 
         if not weaviate_host:
-            raise RuntimeError("Weaviate is not configured for this Agent")
+            msg = "Weaviate is not configured for this Agent"
+            raise RuntimeError(msg)
 
         client = WeaviateClient(
             hass=self.hass,
@@ -699,7 +718,7 @@ class LocalAiEntity(Entity):
                     object_uuid=object_uuid,
                 )
 
-                _LOGGER.info(f"Object updated in Weaviate: {object_uuid}")
+                _LOGGER.info("Object updated in Weaviate: %s", object_uuid)
                 return
 
         # Object does not exist, create new object
@@ -710,4 +729,4 @@ class LocalAiEntity(Entity):
             object_uuid=object_uuid,
         )
 
-        _LOGGER.info(f"Object added to Weaviate class: {weaviate_class}")
+        _LOGGER.info("Object added to Weaviate class: %s", weaviate_class)

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -6,7 +6,8 @@
         "data": {
           "server_name": "Server Name",
           "base_url": "Server URL",
-          "api_key": "API key"
+           "api_key": "API key",
+          "server_type": "Server Type"
         },
         "data_description": {
           "api_key": "If required to authenticate with the service"
@@ -41,7 +42,8 @@
         "data": {
           "server_name": "Server Name",
           "base_url": "Server URL",
-          "api_key": "API key"
+          "api_key": "API key",
+          "server_type": "Server Type"
         },
         "data_description": {
           "api_key": "If required to authenticate with the service"
@@ -111,6 +113,15 @@
                 "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
               }
             },
+            "deepseek_config": {
+              "name": "DeepSeek Configuration",
+              "data": {
+                "deepseek_reasoning_effort": "Reasoning effort"
+              },
+              "data_description": {
+                "deepseek_reasoning_effort": "Controls the depth of the model's reasoning. Leave empty to disable thinking."
+              }
+            },
             "weaviate_options": {
               "name": "Weaviate configuration",
               "data": {
@@ -151,6 +162,15 @@
               "name": "Chat Template Arguments",
               "data": {
                 "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
+              }
+            },
+            "deepseek_config": {
+              "name": "DeepSeek Configuration",
+              "data": {
+                "deepseek_reasoning_effort": "Reasoning effort"
+              },
+              "data_description": {
+                "deepseek_reasoning_effort": "Controls the depth of the model's reasoning. Leave empty to disable thinking."
               }
             },
             "weaviate_options": {
@@ -206,6 +226,15 @@
               "data": {
                 "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
               }
+            },
+            "deepseek_config": {
+              "name": "DeepSeek Configuration",
+              "data": {
+                "deepseek_reasoning_effort": "Reasoning effort"
+              },
+              "data_description": {
+                "deepseek_reasoning_effort": "Controls the depth of the model's reasoning. Leave empty to disable thinking."
+              }
             }
           }
         },
@@ -231,6 +260,15 @@
               "name": "Chat Template Arguments",
               "data": {
                 "chat_template_kwargs": "Add custom arguments that are supported by your chosen model"
+              }
+            },
+            "deepseek_config": {
+              "name": "DeepSeek Configuration",
+              "data": {
+                "deepseek_reasoning_effort": "Reasoning effort"
+              },
+              "data_description": {
+                "deepseek_reasoning_effort": "Controls the depth of the model's reasoning. Leave empty to disable thinking."
               }
             }
           }


### PR DESCRIPTION
A whole lot of fixes around ruff
Begin adding support for server-specific configurations, eg vllm, llamacpp, deepseek, etc
- Subclass the aitask & conversation entities and override methods to handle server-specific configuration options
- Shift _convert_content_to_chat_message to the entity class and add override methods for handling also
- Merge extra_body_args in from our subclass override (shallow merge for the time being)
- Config flow injects a new section for server config, where available, as a collapsed-by-default section

Add DeepSeek Cloud reasoning options and feed-back in the thinking content
- Untested: I don't have a DeepSeek API key at this time
- https://github.com/skye-harris/hass_local_openai_llm/issues/72