### PR TITLE
docs: add Requesty to the list of supported OpenAI-compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - LM Studio
 - Ollama
 - OpenRouter
+- Requesty
 - Scaleway
 - DeepSeek
 


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) to the README list of supported OpenAI-compatible services, alongside the other hosted gateways already listed (OpenRouter, DeepSeek, Scaleway).

Requesty is an OpenAI-compatible LLM gateway. With this integration you'd set the **Server URL** to `https://router.requesty.ai/v1` and provide a Requesty API key — no code changes needed, since the integration already takes a configurable `base_url` and API key.

## Tested

Verified the OpenAI-compatible endpoint (`https://router.requesty.ai/v1`) with the OpenAI SDK — both streaming and non-streaming chat completions work, using `provider/model` model names. That matches how this integration (forked from HA's OpenRouter component) calls the API, including the `HTTP-Referer` header it already sends.

## Disclosure

I work at Requesty. This is a one-line docs addition to the "such as (but not limited to)" provider list. Happy to adjust or close if you'd rather not list it.