### PR TITLE
fix: prevent duplicate tool calls from double finish chunks

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -448,6 +448,7 @@ class LocalAiEntity(Entity):
                         for key, tool_call in pending_tool_calls.items()
                     ]
                     _LOGGER.debug("Calling tools: %s", pending_tool_calls)
+                    pending_tool_calls.clear()
 
             if (
                 seen_visible


### PR DESCRIPTION
OpenRouter sends two chunks with finish_reason='tool_calls' - one for the actual finish and one for usage data. The pending_tool_calls dict was never cleared after emission, causing the second chunk to re-emit the same tool calls.

This caused duplicate tool calls when using on openrouter