### PR TITLE
Add LocalAI server type

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -16,6 +16,7 @@ ignore = [
     "ARG001",  # Unused argument
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
     "COM812",  # Incompatible with formatter
+    "EXE002",  # The file is executable but no shebang is present
 ]
 
 [lint.flake8-pytest-style]

--- a/README.md
+++ b/README.md
@@ -111,15 +111,6 @@ When enabled, thinking content returned by the model is also fed back into the c
 
 When the server type is set to *llama.cpp*, both conversation and AI task agents show a **llama.cpp Configuration** section with the following options.
 
-### LocalAI Configuration
-
-When the server type is set to *LocalAI*, Chat Template Arguments are sent via the
-`metadata` request field rather than `chat_template_kwargs`, as this is where LocalAI
-reads chat template variables from. Values are coerced to strings, per LocalAI's
-metadata convention.
-
-See [LocalAI PR #10359](https://github.com/mudler/LocalAI/pull/10359).
-
 #### Enable thinking
 
 Passes `enable_thinking=true` via `chat_template_kwargs` to enable reasoning on supported models.
@@ -159,6 +150,17 @@ Please refer to the [llama.cpp documentation](https://github.com/ggml-org/llama.
 | **Top-K**            | Limits sampling to the k highest-probability tokens.                                                       | 1–1000 |
 | **Repeat Penalty**   | Penalizes repeat sequences of tokens.                                                                      | -2–2   |
 | **Presence Penalty** | Penalizes tokens already present in the context.                                                           | -2–2   |
+
+---
+
+### LocalAI Configuration
+
+When the server type is set to *LocalAI*, Chat Template Arguments are sent via the
+OpenAI `metadata` request field rather than a top-level `chat_template_kwargs` field,
+as this is where LocalAI reads chat template variables from. Values are coerced to
+strings, per LocalAI's metadata convention.
+
+See [LocalAI model configuration](https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Requesty
 - Scaleway
 - DeepSeek
+- LocalAI
 
 **This integration has been forked from Home Assistants OpenRouter integration, with the following changes:**
 
@@ -109,6 +110,15 @@ When enabled, thinking content returned by the model is also fed back into the c
 ### llama.cpp Configuration
 
 When the server type is set to *llama.cpp*, both conversation and AI task agents show a **llama.cpp Configuration** section with the following options.
+
+### LocalAI Configuration
+
+When the server type is set to *LocalAI*, Chat Template Arguments are sent via the
+`metadata` request field rather than `chat_template_kwargs`, as this is where LocalAI
+reads chat template variables from. Values are coerced to strings, per LocalAI's
+metadata convention.
+
+See [LocalAI PR #10359](https://github.com/mudler/LocalAI/pull/10359).
 
 #### Enable thinking
 

--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -29,6 +29,7 @@ from .const import (
     SERVER_TYPE_DEEPSEEK,
     SERVER_TYPE_GENERIC,
     SERVER_TYPE_LLAMACPP,
+    SERVER_TYPE_LOCALAI,
 )
 from .entity import LocalAiEntity
 
@@ -46,11 +47,14 @@ def _get_ai_task_entity(
     if getattr(_get_ai_task_entity, "entity_map", None) is None:
         from .entities.deepseek import DeepSeekAITaskEntity  # noqa: PLC0415
         from .entities.llama_cpp import LlamaCppAITaskEntity  # noqa: PLC0415
+        from .entities.localai import LocalAIServerAITaskEntity  # noqa: PLC0415
 
         _get_ai_task_entity.entity_map = {
             SERVER_TYPE_DEEPSEEK: DeepSeekAITaskEntity,
             SERVER_TYPE_LLAMACPP: LlamaCppAITaskEntity,
+            SERVER_TYPE_LOCALAI: LocalAIServerAITaskEntity,
         }
+
     return _get_ai_task_entity.entity_map.get(server_type, LocalAITaskEntity)
 
 

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -39,12 +39,14 @@ SERVER_TYPE_GENERIC = "generic"
 SERVER_TYPE_LLAMACPP = "llama_cpp"
 SERVER_TYPE_VLLM = "vllm"
 SERVER_TYPE_DEEPSEEK = "deepseek"
+SERVER_TYPE_LOCALAI = "localai"
 
 SERVER_TYPE_OPTIONS = {
     SERVER_TYPE_GENERIC: "Generic OpenAI-Compatible",
     SERVER_TYPE_LLAMACPP: "llama.cpp",
     # SERVER_TYPE_VLLM: "vLLM",
     SERVER_TYPE_DEEPSEEK: "DeepSeek Cloud",
+    SERVER_TYPE_LOCALAI: "LocalAI"
 }
 
 CONF_AI_TASK_SUPPORTED_ATTRIBUTES = "supported_attributes"

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -46,7 +46,7 @@ SERVER_TYPE_OPTIONS = {
     SERVER_TYPE_LLAMACPP: "llama.cpp",
     # SERVER_TYPE_VLLM: "vLLM",
     SERVER_TYPE_DEEPSEEK: "DeepSeek Cloud",
-    SERVER_TYPE_LOCALAI: "LocalAI"
+    SERVER_TYPE_LOCALAI: "LocalAI",
 }
 
 CONF_AI_TASK_SUPPORTED_ATTRIBUTES = "supported_attributes"

--- a/custom_components/local_openai/conversation.py
+++ b/custom_components/local_openai/conversation.py
@@ -15,6 +15,7 @@ from .const import (
     SERVER_TYPE_DEEPSEEK,
     SERVER_TYPE_GENERIC,
     SERVER_TYPE_LLAMACPP,
+    SERVER_TYPE_LOCALAI,
 )
 from .entity import LocalAiEntity
 
@@ -32,16 +33,18 @@ def _get_conversation_entity(
     if getattr(_get_conversation_entity, "entity_map", None) is None:
         from .entities.deepseek import DeepSeekConversationEntity  # noqa: PLC0415
         from .entities.llama_cpp import LlamaCppConversationEntity  # noqa: PLC0415
+        from .entities.localai import LocalAIServerConversationEntity  # noqa: PLC0415
 
         _get_conversation_entity.entity_map = {
             SERVER_TYPE_DEEPSEEK: DeepSeekConversationEntity,
             SERVER_TYPE_LLAMACPP: LlamaCppConversationEntity,
+            SERVER_TYPE_LOCALAI: LocalAIServerConversationEntity,
         }
+
     return _get_conversation_entity.entity_map.get(
         server_type,
         LocalAiConversationEntity,
     )
-
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/local_openai/conversation.py
+++ b/custom_components/local_openai/conversation.py
@@ -46,6 +46,7 @@ def _get_conversation_entity(
         LocalAiConversationEntity,
     )
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: LocalAiConfigEntry,

--- a/custom_components/local_openai/entities/localai.py
+++ b/custom_components/local_openai/entities/localai.py
@@ -1,0 +1,39 @@
+"""Server-specific entities for LocalAI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.local_openai.ai_task import LocalAITaskEntity
+from custom_components.local_openai.conversation import LocalAiConversationEntity
+
+
+class LocalAIServerMixin:
+    """Mixin for LocalAI server entities with shared logic.
+
+    LocalAI does not read a top-level ``chat_template_kwargs`` field the way
+    llama.cpp's server does. Chat template variables are supplied via the
+    OpenAI ``metadata`` field, with string values.
+
+    See https://github.com/mudler/LocalAI/pull/10359
+    """
+
+    _chat_template_kwargs_key = "metadata"
+
+    # noinspection PyMethodMayBeStatic
+    def _format_chat_template_kwarg(self, value: Any) -> Any:
+        """LocalAI expects metadata values as strings."""
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value)
+
+
+class LocalAIServerConversationEntity(
+    LocalAIServerMixin,
+    LocalAiConversationEntity,
+):
+    """Conversation agent for LocalAI servers."""
+
+
+class LocalAIServerAITaskEntity(LocalAIServerMixin, LocalAITaskEntity):
+    """AI Task entity for LocalAI servers."""

--- a/custom_components/local_openai/entities/localai.py
+++ b/custom_components/local_openai/entities/localai.py
@@ -8,25 +8,36 @@ from custom_components.local_openai.ai_task import LocalAITaskEntity
 from custom_components.local_openai.conversation import LocalAiConversationEntity
 
 
+def _to_metadata_value(value: Any) -> str:
+    """LocalAI's per-request metadata field is string-only.
+
+    See https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs
+    """
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
 class LocalAIServerMixin:
-    """Mixin for LocalAI server entities with shared logic.
+    """Mixin for LocalAI entities.
 
     LocalAI does not read a top-level ``chat_template_kwargs`` field the way
     llama.cpp's server does. Chat template variables are supplied via the
     OpenAI ``metadata`` field, with string values.
 
-    See https://github.com/mudler/LocalAI/pull/10359
+    See https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs
     """
 
-    _chat_template_kwargs_key = "metadata"
+    def _get_extra_body_args(self, options: dict) -> dict:
+        """Route chat template kwargs into `metadata` as strings for LocalAI."""
+        extra_body_args = super()._get_extra_body_args(options)
 
-    # noinspection PyMethodMayBeStatic
-    def _format_chat_template_kwarg(self, value: Any) -> Any:
-        """LocalAI expects metadata values as strings."""
-        if isinstance(value, bool):
-            return str(value).lower()
-        return str(value)
+        kwargs = extra_body_args.pop("chat_template_kwargs", None)
+        if kwargs:
+            metadata = extra_body_args.setdefault("metadata", {})
+            for key, value in kwargs.items():
+                metadata[key] = _to_metadata_value(value)
 
+        return extra_body_args
 
 class LocalAIServerConversationEntity(
     LocalAIServerMixin,

--- a/custom_components/local_openai/entities/localai.py
+++ b/custom_components/local_openai/entities/localai.py
@@ -9,7 +9,8 @@ from custom_components.local_openai.conversation import LocalAiConversationEntit
 
 
 def _to_metadata_value(value: Any) -> str:
-    """LocalAI's per-request metadata field is string-only.
+    """
+    LocalAI's per-request metadata field is string-only.
 
     See https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs
     """
@@ -17,8 +18,10 @@ def _to_metadata_value(value: Any) -> str:
         return str(value).lower()
     return str(value)
 
+
 class LocalAIServerMixin:
-    """Mixin for LocalAI entities.
+    """
+    Mixin for LocalAI entities.
 
     LocalAI does not read a top-level ``chat_template_kwargs`` field the way
     llama.cpp's server does. Chat template variables are supplied via the
@@ -38,6 +41,7 @@ class LocalAIServerMixin:
                 metadata[key] = _to_metadata_value(value)
 
         return extra_body_args
+
 
 class LocalAIServerConversationEntity(
     LocalAIServerMixin,

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -169,6 +169,7 @@ class LocalAiEntity(Entity):
     """Base entity for Open Router."""
 
     _attr_has_entity_name = True
+
     def __init__(self, entry: LocalAiConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the entity."""
         self.entry = entry
@@ -182,7 +183,8 @@ class LocalAiEntity(Entity):
         )
 
     def _get_extra_body_args(self, options: dict) -> dict:
-        """Build extra_body args for the completion request.
+        """
+        Build extra_body args for the completion request.
 
         Chat Template Arguments are sent as a top-level `chat_template_kwargs`
         field, which most inference servers (llama.cpp, vLLM) read. Server-type

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -169,12 +169,6 @@ class LocalAiEntity(Entity):
     """Base entity for Open Router."""
 
     _attr_has_entity_name = True
-    
-    # extra_body key under which chat template kwargs are sent. Most inference
-    # servers read a top-level `chat_template_kwargs`; LocalAI reads them from
-    # `metadata` instead.
-    _chat_template_kwargs_key = "chat_template_kwargs"
-
     def __init__(self, entry: LocalAiConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the entity."""
         self.entry = entry
@@ -187,15 +181,34 @@ class LocalAiEntity(Entity):
             entry_type=dr.DeviceEntryType.SERVICE,
         )
 
-    # noinspection PyMethodMayBeStatic
-    def _get_extra_body_args(self, _options: dict) -> dict:
-        return {}
+    def _get_extra_body_args(self, options: dict) -> dict:
+        """Build extra_body args for the completion request.
 
-    # noinspection PyMethodMayBeStatic
-    def _format_chat_template_kwarg(self, value: Any) -> Any:
-        """Format a rendered chat template kwarg for the target server."""
-        return value
-    
+        Chat Template Arguments are sent as a top-level `chat_template_kwargs`
+        field, which most inference servers (llama.cpp, vLLM) read. Server-type
+        subclasses may override this to deliver them elsewhere.
+        """
+        extra_body_args: dict = {}
+
+        chat_template_opts = options.get(CONF_CHAT_TEMPLATE_OPTS, {})
+        chat_template_args = chat_template_opts.get(CONF_CHAT_TEMPLATE_KWARGS, [])
+        chat_template_args = [
+            keypair for keypair in chat_template_args if keypair["Key"].strip()
+        ]
+
+        if chat_template_args:
+            kwargs = {}
+            for keypair in chat_template_args:
+                if keypair["Key"]:
+                    # Value is a template, so non-string types and structures can be provided
+                    kwargs[keypair["Key"]] = template.Template(
+                        keypair["Value"],
+                        self.hass,
+                    ).async_render()
+            extra_body_args["chat_template_kwargs"] = kwargs
+
+        return extra_body_args
+
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
@@ -595,34 +608,7 @@ class LocalAiEntity(Entity):
 
         if tools:
             model_args["tools"] = tools
-
-        chat_template_opts = options.get(CONF_CHAT_TEMPLATE_OPTS, {})
-        chat_template_args = chat_template_opts.get(CONF_CHAT_TEMPLATE_KWARGS, [])
-
-        # Filter args without a name - they are marked as required in the schema but this isn't being enforced on the front-end
-        chat_template_args = [
-            keypair for keypair in chat_template_args if keypair["Key"].strip()
-        ]
-
-        # Additional args to be passed into extra_body:
-        # - chat_template_kwargs is supported in multiple inference servers, args depend on model support
-        # - metadata.session_id is supported by LiteLLM for observability & tracing in langfuse
-        extra_body_args = {}
-        if chat_template_args:
-            kwargs = {}
-            for keypair in chat_template_args:
-                if keypair["Key"]:
-                    # Our value is a template, so that non-string data types and more complex structures can be provided by the user
-                    kwargs[keypair["Key"]] = self._format_chat_template_kwarg(
-                        template.Template(
-                            keypair["Value"],
-                            self.hass,
-                        ).async_render(),
-                    )
-            extra_body_args.setdefault(self._chat_template_kwargs_key, {}).update(
-                kwargs,
-            )
-
+        extra_body_args = self._get_extra_body_args(options)
         # Pass conversation session ID via metadata for LLM proxy tracing (LiteLLM + Langfuse)
         if (
             pass_session_id
@@ -633,11 +619,6 @@ class LocalAiEntity(Entity):
             extra_body_args.setdefault("metadata", {})["session_id"] = (
                 user_input.conversation_id
             )
-        for key, value in self._get_extra_body_args(options).items():
-            if isinstance(value, dict) and isinstance(extra_body_args.get(key), dict):
-                extra_body_args[key] = {**extra_body_args[key], **value}
-            else:
-                extra_body_args[key] = value
 
         # Insert our extra_body args if we have any
         if extra_body_args:

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -169,6 +169,11 @@ class LocalAiEntity(Entity):
     """Base entity for Open Router."""
 
     _attr_has_entity_name = True
+    
+    # extra_body key under which chat template kwargs are sent. Most inference
+    # servers read a top-level `chat_template_kwargs`; LocalAI reads them from
+    # `metadata` instead.
+    _chat_template_kwargs_key = "chat_template_kwargs"
 
     def __init__(self, entry: LocalAiConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the entity."""
@@ -186,6 +191,11 @@ class LocalAiEntity(Entity):
     def _get_extra_body_args(self, _options: dict) -> dict:
         return {}
 
+    # noinspection PyMethodMayBeStatic
+    def _format_chat_template_kwarg(self, value: Any) -> Any:
+        """Format a rendered chat template kwarg for the target server."""
+        return value
+    
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
@@ -603,11 +613,15 @@ class LocalAiEntity(Entity):
             for keypair in chat_template_args:
                 if keypair["Key"]:
                     # Our value is a template, so that non-string data types and more complex structures can be provided by the user
-                    kwargs[keypair["Key"]] = template.Template(
-                        keypair["Value"],
-                        self.hass,
-                    ).async_render()
-            extra_body_args["chat_template_kwargs"] = kwargs
+                    kwargs[keypair["Key"]] = self._format_chat_template_kwarg(
+                        template.Template(
+                            keypair["Value"],
+                            self.hass,
+                        ).async_render(),
+                    )
+            extra_body_args.setdefault(self._chat_template_kwargs_key, {}).update(
+                kwargs,
+            )
 
         # Pass conversation session ID via metadata for LLM proxy tracing (LiteLLM + Langfuse)
         if (
@@ -616,10 +630,9 @@ class LocalAiEntity(Entity):
             and hasattr(user_input, "conversation_id")
             and user_input.conversation_id
         ):
-            extra_body_args["metadata"] = {
-                "session_id": user_input.conversation_id,
-            }
-
+            extra_body_args.setdefault("metadata", {})["session_id"] = (
+                user_input.conversation_id
+            )
         for key, value in self._get_extra_body_args(options).items():
             if isinstance(value, dict) and isinstance(extra_body_args.get(key), dict):
                 extra_body_args[key] = {**extra_body_args[key], **value}


### PR DESCRIPTION
### Problem
[LocalAI](https://github.com/mudler/LocalAI) is an OpenAI-compatible inference server, but Chat Template Arguments silently do nothing against it. The integration sends them as a top-level chat_template_kwargs field, which llama.cpp's server reads. LocalAI doesn't — it reads chat template variables from the OpenAI metadata field, with string values.
The failure is silent: the field is accepted, dropped server-side, and the user sees no error. With enable_thinking: false set and ignored, a reasoning model keeps emitting reasoning — in my case ~400 completion tokens per turn instead of ~20, adding roughly 3 seconds to every voice command.
See [mudler/LocalAI#10359](https://github.com/mudler/LocalAI/pull/10359) for LocalAI's per-request precedence (config map < server reasoning levers < per-request metadata) and the string-value convention.

### Changes

- New SERVER_TYPE_LOCALAI following the existing server-type pattern
- entity.py: extracted the extra_body key into _chat_template_kwargs_key, and value formatting into _format_chat_template_kwarg(). Defaults are unchanged, so all existing server types behave identically.
- entities/localai.py: mixin overriding both, routing kwargs to metadata as strings
- Wired into the conversation and AI task entity maps

### Incidental fix
extra_body_args["metadata"] was assigned directly by the pass_session_id path. Now setdefault().update(), so the session ID and LocalAI's kwargs can coexist rather than clobbering each other.

### Notes

- No new config options — LocalAI reuses the existing Chat Template Arguments field, just delivered where LocalAI reads it.
- No config migration needed; existing entries keep their server type.
- Tested against LocalAI v4.7.1 with gemma-4-26b-a4b-it-qat: enable_thinking: false now takes effect (~400 → ~20 completion tokens).

**AI was used for this entire change. I don't know python and didn't have the time to learn it or understand the overall structure of this project but needed a fix for this issue on my end.**