### PR TITLE
Enable the vLLM server type, with a configurable thinking token budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,30 @@ as this is where LocalAI reads chat template variables from. Values are coerced 
 strings, per LocalAI's metadata convention.
 
 See [LocalAI model configuration](https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs).
+---
+
+### vLLM Configuration
+
+When the server type is set to *vLLM*, both conversation and AI task agents show a **vLLM Configuration** section with the following options.
+
+#### Thinking token budget
+
+Caps how many tokens the model may spend on reasoning, via the `thinking_token_budget` request parameter. Once the budget is reached, vLLM forces the reasoning block to be closed and the model proceeds to its answer.
+
+- **Empty** (default) — no budget is sent, and the server default applies.
+- **0** — the reasoning block is closed immediately, so the model answers without thinking.
+- **Any higher value** — limits reasoning to that number of tokens.
+
+_Note: This only limits the length of thinking, it does not enable or disable it. Whether the model thinks at all is controlled by the model's chat template, typically via an `enable_thinking` Chat Template Argument._
+
+Requires a reasoning model and a vLLM version that supports the parameter. Refer to the [vLLM reasoning outputs documentation](https://docs.vllm.ai/en/latest/features/reasoning_outputs/) for further information.
+
+When the budget is reached the reasoning block is closed with the parser's end string, which can leave the model cut off mid-thought. A wrap-up message can be added there to transition into the answer more gracefully, though this is configured on the vLLM server rather than per request:
+
+```
+--reasoning-parser qwen3
+--reasoning-config '{"reasoning_start_str": "<think>", "reasoning_end_str": "\n\nTime to wrap up my reasoning and answer.</think>"}'
+```
 
 ---
 

--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -30,6 +30,7 @@ from .const import (
     SERVER_TYPE_GENERIC,
     SERVER_TYPE_LLAMACPP,
     SERVER_TYPE_LOCALAI,
+    SERVER_TYPE_VLLM,
 )
 from .entity import LocalAiEntity
 
@@ -48,11 +49,13 @@ def _get_ai_task_entity(
         from .entities.deepseek import DeepSeekAITaskEntity  # noqa: PLC0415
         from .entities.llama_cpp import LlamaCppAITaskEntity  # noqa: PLC0415
         from .entities.localai import LocalAIServerAITaskEntity  # noqa: PLC0415
+        from .entities.vllm import VllmAITaskEntity  # noqa: PLC0415
 
         _get_ai_task_entity.entity_map = {
             SERVER_TYPE_DEEPSEEK: DeepSeekAITaskEntity,
             SERVER_TYPE_LLAMACPP: LlamaCppAITaskEntity,
             SERVER_TYPE_LOCALAI: LocalAIServerAITaskEntity,
+            SERVER_TYPE_VLLM: VllmAITaskEntity,
         }
 
     return _get_ai_task_entity.entity_map.get(server_type, LocalAITaskEntity)

--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -43,6 +43,12 @@ from custom_components.local_openai.entities.llama_cpp import (
 from custom_components.local_openai.entities.llama_cpp import (
     get_model_alias as _llama_cpp_model_alias,
 )
+from custom_components.local_openai.entities.vllm import (
+    get_ai_task_config_schema as _vllm_ai_task_schema,
+)
+from custom_components.local_openai.entities.vllm import (
+    get_conversation_config_schema as _vllm_conversation_schema,
+)
 
 from .const import (
     CONF_AI_TASK_SUPPORTED_ATTRIBUTES,
@@ -127,6 +133,7 @@ def _get_conversation_config_schema(server_type: str) -> dict:
     provider = {
         SERVER_TYPE_DEEPSEEK: _deepseek_conversation_schema,
         SERVER_TYPE_LLAMACPP: _llama_cpp_conversation_schema,
+        SERVER_TYPE_VLLM: _vllm_conversation_schema,
     }.get(server_type)
     return provider() if provider else {}
 
@@ -136,6 +143,7 @@ def _get_ai_task_config_schema(server_type: str) -> dict:
     provider = {
         SERVER_TYPE_DEEPSEEK: _deepseek_conversation_schema,
         SERVER_TYPE_LLAMACPP: _llama_cpp_ai_task_schema,
+        SERVER_TYPE_VLLM: _vllm_ai_task_schema,
     }.get(server_type)
     return provider() if provider else {}
 

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -32,6 +32,7 @@ CONF_LLAMACPP_MIN_P = "llamacpp_min_p"
 CONF_LLAMACPP_REPEAT_PENALTY = "llamacpp_repeat_penalty"
 CONF_LLAMACPP_PRESENCE_PENALTY = "llamacpp_presence_penalty"
 CONF_VLLM_CONFIG = "vllm_config"
+CONF_VLLM_THINKING_TOKEN_BUDGET = "vllm_thinking_token_budget"  # noqa: S105
 CONF_DEEPSEEK_CONFIG = "deepseek_config"
 CONF_DEEPSEEK_REASONING_EFFORT = "deepseek_reasoning_effort"
 
@@ -44,7 +45,7 @@ SERVER_TYPE_LOCALAI = "localai"
 SERVER_TYPE_OPTIONS = {
     SERVER_TYPE_GENERIC: "Generic OpenAI-Compatible",
     SERVER_TYPE_LLAMACPP: "llama.cpp",
-    # SERVER_TYPE_VLLM: "vLLM",
+    SERVER_TYPE_VLLM: "vLLM",
     SERVER_TYPE_DEEPSEEK: "DeepSeek Cloud",
     SERVER_TYPE_LOCALAI: "LocalAI",
 }

--- a/custom_components/local_openai/conversation.py
+++ b/custom_components/local_openai/conversation.py
@@ -16,6 +16,7 @@ from .const import (
     SERVER_TYPE_GENERIC,
     SERVER_TYPE_LLAMACPP,
     SERVER_TYPE_LOCALAI,
+    SERVER_TYPE_VLLM,
 )
 from .entity import LocalAiEntity
 
@@ -34,11 +35,13 @@ def _get_conversation_entity(
         from .entities.deepseek import DeepSeekConversationEntity  # noqa: PLC0415
         from .entities.llama_cpp import LlamaCppConversationEntity  # noqa: PLC0415
         from .entities.localai import LocalAIServerConversationEntity  # noqa: PLC0415
+        from .entities.vllm import VllmConversationEntity  # noqa: PLC0415
 
         _get_conversation_entity.entity_map = {
             SERVER_TYPE_DEEPSEEK: DeepSeekConversationEntity,
             SERVER_TYPE_LLAMACPP: LlamaCppConversationEntity,
             SERVER_TYPE_LOCALAI: LocalAIServerConversationEntity,
+            SERVER_TYPE_VLLM: VllmConversationEntity,
         }
 
     return _get_conversation_entity.entity_map.get(

--- a/custom_components/local_openai/entities/vllm.py
+++ b/custom_components/local_openai/entities/vllm.py
@@ -1,0 +1,65 @@
+"""Server-specific entities for vLLM."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
+
+from custom_components.local_openai.ai_task import LocalAITaskEntity
+from custom_components.local_openai.const import (
+    CONF_VLLM_CONFIG,
+    CONF_VLLM_THINKING_TOKEN_BUDGET,
+)
+from custom_components.local_openai.conversation import LocalAiConversationEntity
+
+
+def _get_vllm_schema() -> dict:
+    """Return the vLLM server configuration schema."""
+    return {
+        vol.Optional(CONF_VLLM_THINKING_TOKEN_BUDGET): NumberSelector(
+            NumberSelectorConfig(
+                min=0,
+                max=32768,
+                step=1,
+                mode=NumberSelectorMode.BOX,
+            ),
+        ),
+    }
+
+
+def get_conversation_config_schema() -> dict:
+    """Return conversation config schema fields for vLLM."""
+    return _get_vllm_schema()
+
+
+def get_ai_task_config_schema() -> dict:
+    """Return AI task config schema fields for vLLM."""
+    return _get_vllm_schema()
+
+
+class VllmMixin:
+    """Mixin for vLLM entities with shared logic."""
+
+    def _get_extra_body_args(self, options: dict) -> dict:
+        """Add the vLLM thinking token budget to the base extra_body args."""
+        extra_body_args = super()._get_extra_body_args(options)
+
+        thinking_token_budget = options.get(CONF_VLLM_CONFIG, {}).get(
+            CONF_VLLM_THINKING_TOKEN_BUDGET,
+        )
+        if thinking_token_budget is not None:
+            extra_body_args["thinking_token_budget"] = int(thinking_token_budget)
+
+        return extra_body_args
+
+
+class VllmConversationEntity(VllmMixin, LocalAiConversationEntity):
+    """Conversation agent for vLLM servers."""
+
+
+class VllmAITaskEntity(VllmMixin, LocalAITaskEntity):
+    """AI Task entity for vLLM servers."""

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -145,6 +145,15 @@
                 "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
               }
             },
+            "vllm_config": {
+              "name": "vLLM Configuration",
+              "data": {
+                "vllm_thinking_token_budget": "Thinking token budget"
+              },
+              "data_description": {
+                "vllm_thinking_token_budget": "Limits how many tokens the model may spend on reasoning, with 0 meaning no thinking at all. Does not enable thinking itself. Leave empty for the server default."
+              }
+            },
             "weaviate_options": {
               "name": "Weaviate configuration",
               "data": {
@@ -217,6 +226,15 @@
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
                 "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+              }
+            },
+            "vllm_config": {
+              "name": "vLLM Configuration",
+              "data": {
+                "vllm_thinking_token_budget": "Thinking token budget"
+              },
+              "data_description": {
+                "vllm_thinking_token_budget": "Limits how many tokens the model may spend on reasoning, with 0 meaning no thinking at all. Does not enable thinking itself. Leave empty for the server default."
               }
             },
             "weaviate_options": {
@@ -304,6 +322,15 @@
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
                 "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
               }
+            },
+            "vllm_config": {
+              "name": "vLLM Configuration",
+              "data": {
+                "vllm_thinking_token_budget": "Thinking token budget"
+              },
+              "data_description": {
+                "vllm_thinking_token_budget": "Limits how many tokens the model may spend on reasoning, with 0 meaning no thinking at all. Does not enable thinking itself. Leave empty for the server default."
+              }
             }
           }
         },
@@ -361,6 +388,15 @@
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
                 "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+              }
+            },
+            "vllm_config": {
+              "name": "vLLM Configuration",
+              "data": {
+                "vllm_thinking_token_budget": "Thinking token budget"
+              },
+              "data_description": {
+                "vllm_thinking_token_budget": "Limits how many tokens the model may spend on reasoning, with 0 meaning no thinking at all. Does not enable thinking itself. Leave empty for the server default."
               }
             }
           }

--- a/tests/entities/vllm/test_schema.py
+++ b/tests/entities/vllm/test_schema.py
@@ -1,0 +1,65 @@
+"""Unit tests for vLLM entity mixin and schema functions."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+import pytest
+
+from custom_components.local_openai.const import (
+    CONF_VLLM_THINKING_TOKEN_BUDGET,
+)
+from custom_components.local_openai.entities.vllm import _get_vllm_schema
+
+
+def test_get_vllm_schema_returns_expected_fields() -> None:
+    """Test that schema includes expected vLLM field."""
+    schema = _get_vllm_schema()
+    assert CONF_VLLM_THINKING_TOKEN_BUDGET in schema
+
+
+def _validator() -> vol.Schema:
+    return vol.Schema(_get_vllm_schema())
+
+
+class TestValidation:
+    """Validation tests for _get_vllm_schema."""
+
+    def test_valid_data_passes(self) -> None:
+        validator = _validator()
+        data = {CONF_VLLM_THINKING_TOKEN_BUDGET: 2048}
+        assert validator(data) == data
+
+    def test_optional_field_can_be_omitted(self) -> None:
+        validator = _validator()
+        result = validator({})
+        assert result == {}
+
+    def test_rejects_non_numeric_string(self) -> None:
+        validator = _validator()
+        with pytest.raises(vol.Invalid):
+            validator({CONF_VLLM_THINKING_TOKEN_BUDGET: "abc"})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            -1,
+            -100,
+            32769,
+            100000,
+        ],
+    )
+    def test_rejects_out_of_range(self, value) -> None:
+        validator = _validator()
+        with pytest.raises(vol.Invalid):
+            validator({CONF_VLLM_THINKING_TOKEN_BUDGET: value})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            32768,
+        ],
+    )
+    def test_accepts_boundary_values(self, value) -> None:
+        validator = _validator()
+        validator({CONF_VLLM_THINKING_TOKEN_BUDGET: value})

--- a/tests/entities/vllm/test_vllm_model_args.py
+++ b/tests/entities/vllm/test_vllm_model_args.py
@@ -52,7 +52,7 @@ class TestVllmExtraBodyArgs:
             ({CONF_VLLM_THINKING_TOKEN_BUDGET: 2048}, {}),
         ],
     )
-    def test_vllm_extra_body_args(self, options: dict, extra_expected: dict):
+    def test_vllm_extra_body_args(self, options: dict, extra_expected: dict) -> None:
         """Test extra body arguments generation with various configurations."""
         result = _StubVllmEntity()._get_extra_body_args(options)
         assert result == BASE_EXTRA_BODY_ARGS | extra_expected

--- a/tests/entities/vllm/test_vllm_model_args.py
+++ b/tests/entities/vllm/test_vllm_model_args.py
@@ -1,0 +1,58 @@
+"""Unit tests for _get_extra_body_args instance method."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.local_openai.const import (
+    CONF_VLLM_CONFIG,
+    CONF_VLLM_THINKING_TOKEN_BUDGET,
+)
+from custom_components.local_openai.entities.vllm import VllmMixin
+
+# Stands in for LocalAiEntity, whose _get_extra_body_args builds chat_template_kwargs
+BASE_EXTRA_BODY_ARGS = {"chat_template_kwargs": {"enable_thinking": True}}
+
+
+class _StubBase:
+    def _get_extra_body_args(self, options: dict) -> dict:
+        return dict(BASE_EXTRA_BODY_ARGS)
+
+
+class _StubVllmEntity(VllmMixin, _StubBase):
+    pass
+
+
+class TestVllmExtraBodyArgs:
+    """Tests for _get_extra_body_args instance method."""
+
+    @pytest.mark.parametrize(
+        "options,extra_expected",
+        [
+            # Budget set
+            (
+                {CONF_VLLM_CONFIG: {CONF_VLLM_THINKING_TOKEN_BUDGET: 2048}},
+                {"thinking_token_budget": 2048},
+            ),
+            # Float budget converted to int
+            (
+                {CONF_VLLM_CONFIG: {CONF_VLLM_THINKING_TOKEN_BUDGET: 512.0}},
+                {"thinking_token_budget": 512},
+            ),
+            # Zero is a valid budget, not "unset"
+            (
+                {CONF_VLLM_CONFIG: {CONF_VLLM_THINKING_TOKEN_BUDGET: 0}},
+                {"thinking_token_budget": 0},
+            ),
+            # No extra options
+            ({CONF_VLLM_CONFIG: {}}, {}),
+            # None config
+            ({}, {}),
+            # Budget must be read from the vLLM section, not the top level
+            ({CONF_VLLM_THINKING_TOKEN_BUDGET: 2048}, {}),
+        ],
+    )
+    def test_vllm_extra_body_args(self, options: dict, extra_expected: dict):
+        """Test extra body arguments generation with various configurations."""
+        result = _StubVllmEntity()._get_extra_body_args(options)
+        assert result == BASE_EXTRA_BODY_ARGS | extra_expected


### PR DESCRIPTION
Enables the vLLM server type (previously commented out in `SERVER_TYPE_OPTIONS`) and adds a
**vLLM Configuration** section with one option, **Thinking token budget**, sent as
`thinking_token_budget` in `extra_body`.

## Why

The integration already covers thinking toggles generically through Chat Template Arguments —
that is where `enable_thinking` belongs, and it is how llama.cpp reasoning is controlled today.
vLLM's reasoning *limit* is not a chat template argument: it is a top-level sampling parameter,
and passing it inside `chat_template_kwargs` is silently ignored. So there was no way to set it
from the UI, hence a dedicated field.

The two are separate levers: `enable_thinking` decides whether a reasoning block is opened,
`thinking_token_budget` decides how long it may run before vLLM forces the parser's end string.

## Implementation

Follows the existing per-server layout instead of special-casing vLLM in the config flow: the
schema lives in `entities/vllm.py` mirroring `entities/llama_cpp.py`, wired through
`_get_conversation_config_schema` / `_get_ai_task_config_schema`, so the value is stored under
`vllm_config` like the llama.cpp and DeepSeek sections. README and translations follow the
existing sections' style.

## Testing

- Unit tests in `tests/entities/vllm/` (budget set, float→int, 0, unset, section-vs-top-level).
  Full suite passes (59).
- Verified live against vLLM 0.25.0 (Qwen3.6-35B-A3B) through the Assist pipeline:
  `Extra-body args: {'chat_template_kwargs': {'enable_thinking': True}, 'thinking_token_budget': 512}`
- Budget `0` verified: reasoning block opens and is closed immediately with the parser's end
  string, model answers with no reasoning tokens generated.