### PR TITLE
Provide placeholder API key since OpenAI fails on falsy

### DIFF
--- a/custom_components/local_openai/__init__.py
+++ b/custom_components/local_openai/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_CHAT_TEMPLATE_OPTS,
     DOMAIN,
     LOGGER,
+    PLACEHOLDER_API_KEY,
 )
 
 PLATFORMS = [Platform.AI_TASK, Platform.CONVERSATION]
@@ -84,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LocalAiConfigEntry) -> b
     """Set up Local OpenAI LLM from a config entry."""
     client = AsyncOpenAI(
         base_url=entry.data[CONF_BASE_URL],
-        api_key=entry.data.get(CONF_API_KEY, ""),
+        api_key=entry.data.get(CONF_API_KEY) or PLACEHOLDER_API_KEY,
         http_client=get_async_client(hass),
     )
 

--- a/custom_components/local_openai/config_flow.py
+++ b/custom_components/local_openai/config_flow.py
@@ -78,6 +78,7 @@ from .const import (
     CONF_WEAVIATE_THRESHOLD,
     DOMAIN,
     LOGGER,
+    PLACEHOLDER_API_KEY,
     RECOMMENDED_CONVERSATION_OPTIONS,
     SERVER_TYPE_DEEPSEEK,
     SERVER_TYPE_GENERIC,
@@ -245,7 +246,7 @@ class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 client = AsyncOpenAI(
                     base_url=user_input.get(CONF_BASE_URL),
-                    api_key=user_input.get(CONF_API_KEY, ""),
+                    api_key=user_input.get(CONF_API_KEY) or PLACEHOLDER_API_KEY,
                     http_client=get_async_client(self.hass),
                 )
 
@@ -295,7 +296,7 @@ class LocalAiConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 client = AsyncOpenAI(
                     base_url=user_input.get(CONF_BASE_URL),
-                    api_key=user_input.get(CONF_API_KEY, ""),
+                    api_key=user_input.get(CONF_API_KEY) or PLACEHOLDER_API_KEY,
                     http_client=get_async_client(self.hass),
                 )
 

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -9,6 +9,8 @@ from homeassistant.helpers import llm
 DOMAIN = "local_openai"
 LOGGER = logging.getLogger(__package__)
 
+PLACEHOLDER_API_KEY = "local-openai"
+
 CONF_RECOMMENDED = "recommended"
 CONF_BASE_URL = "base_url"
 CONF_SERVER_NAME = "server_name"


### PR DESCRIPTION
HA 2026.8 updated to include a newer version of OpenAI which now fails on any falsy API_KEY not just `None`. This adds a placeholder in case the user is not setting one.