### PR TITLE
Preserve tool-call extra_content across the agent loop for Gemini thought_signature

### DIFF
--- a/custom_components/local_openai/entities/deepseek.py
+++ b/custom_components/local_openai/entities/deepseek.py
@@ -92,9 +92,13 @@ class DeepSeekConversationEntity(LocalAiConversationEntity):
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
+        tool_call_extra_content: dict[str, Any] | None = None,
     ) -> ChatCompletionMessageParam | None:
         """Handle chat message conversion for DeepSeek."""
-        param = await super()._convert_content_to_chat_message(content)
+        param = await super()._convert_content_to_chat_message(
+            content,
+            tool_call_extra_content=tool_call_extra_content,
+        )
         return await _deepseek_augment_content_message(self.subentry, param, content)
 
 
@@ -108,7 +112,11 @@ class DeepSeekAITaskEntity(LocalAITaskEntity):
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
+        tool_call_extra_content: dict[str, Any] | None = None,
     ) -> ChatCompletionMessageParam | None:
         """Handle chat message conversion for DeepSeek."""
-        param = await super()._convert_content_to_chat_message(content)
+        param = await super()._convert_content_to_chat_message(
+            content,
+            tool_call_extra_content=tool_call_extra_content,
+        )
         return await _deepseek_augment_content_message(self.subentry, param, content)

--- a/custom_components/local_openai/entities/llama_cpp.py
+++ b/custom_components/local_openai/entities/llama_cpp.py
@@ -154,10 +154,14 @@ class LlamaCppMixin:
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
+        tool_call_extra_content: dict[str, Any] | None = None,
     ) -> ChatCompletionMessageParam | None:
         """If include_prior_reasoning is enabled, pass prior thinking content back in the request."""
         opts = self.subentry.data.get(CONF_LLAMACPP_CONFIG, {})
-        param = await super()._convert_content_to_chat_message(content)
+        param = await super()._convert_content_to_chat_message(
+            content,
+            tool_call_extra_content=tool_call_extra_content,
+        )
 
         if (
             opts.get(CONF_LLAMACPP_INCLUDE_PRIOR_THINKING, True)

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -176,6 +176,11 @@ class LocalAiEntity(Entity):
         self.subentry = subentry
         self.model = subentry.data[CONF_MODEL]
         self._attr_unique_id = subentry.subentry_id
+        # Provider-specific tool-call metadata (e.g. Gemini 3.x
+        # thought_signature) keyed by tool_call.id, kept across turns since
+        # chat_log.content is rebuilt into `messages` fresh on every turn.
+        # GC'd in _async_handle_chat_log against the current chat_log.
+        self._tool_call_extra_content: dict[str, Any] = {}
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, subentry.subentry_id)},
             name=subentry.title,
@@ -229,6 +234,7 @@ class LocalAiEntity(Entity):
     async def _convert_content_to_chat_message(
         self,
         content: conversation.Content,
+        tool_call_extra_content: dict[str, Any] | None = None,
     ) -> ChatCompletionMessageParam | None:
         if isinstance(content, conversation.ToolResultContent):
 
@@ -296,8 +302,9 @@ class LocalAiEntity(Entity):
                 isinstance(content, conversation.AssistantContent)
                 and content.tool_calls
             ):
-                param["tool_calls"] = [
-                    ChatCompletionMessageFunctionToolCallParam(
+                tool_call_params = []
+                for tool_call in content.tool_calls:
+                    tool_call_param = ChatCompletionMessageFunctionToolCallParam(
                         type="function",
                         id=tool_call.id,
                         function=Function(
@@ -305,8 +312,14 @@ class LocalAiEntity(Entity):
                             name=tool_call.tool_name,
                         ),
                     )
-                    for tool_call in content.tool_calls
-                ]
+                    if tool_call_extra_content and (
+                        extra_content := tool_call_extra_content.get(tool_call.id)
+                    ):
+                        # Providers such as Gemini 3.x require this to be echoed back
+                        # verbatim on the next turn (e.g. thought_signature)
+                        tool_call_param["extra_content"] = extra_content
+                    tool_call_params.append(tool_call_param)
+                param["tool_calls"] = tool_call_params
             return param
         _LOGGER.warning("Could not convert message to Completions API: %s", content)
         return None
@@ -427,10 +440,45 @@ class LocalAiEntity(Entity):
                     ]
         return messages, tools
 
+    @staticmethod
+    def _accumulate_tool_call_delta(
+        pending_tool_calls: dict[str, dict[str, Any]],
+        tool_key: str,
+        tool_call_id: str,
+        tool_call: Any,
+    ) -> None:
+        """Merge one streamed tool-call delta into the pending accumulator."""
+        # Non-standard field some providers (e.g. Gemini 3.x via an
+        # OpenAI-compatible proxy) attach to a tool call to be echoed
+        # back verbatim on the next turn (thought_signature and similar)
+        extra_content = getattr(tool_call, "extra_content", None)
+        if tool_key not in pending_tool_calls:
+            pending_tool_calls[tool_key] = {
+                "id": tool_call_id,
+                "name": tool_call.function.name,
+                "args": tool_call.function.arguments or "",
+                "extra_content": extra_content,
+            }
+        else:
+            pending_tool_calls[tool_key]["args"] += tool_call.function.arguments or ""
+            if extra_content is not None:
+                pending_tool_calls[tool_key]["extra_content"] = extra_content
+
+    @staticmethod
+    def _collect_tool_call_extra_content(
+        pending_tool_calls: dict[str, dict[str, Any]],
+        tool_call_extra_content: dict[str, Any],
+    ) -> None:
+        """Copy accumulated extra_content out by tool_call id for the next request."""
+        for tool_call in pending_tool_calls.values():
+            if tool_call["extra_content"] is not None:
+                tool_call_extra_content[tool_call["id"]] = tool_call["extra_content"]
+
     async def _transform_stream(  # noqa: C901 todo: will break this up
         self,
         stream: AsyncStream[ChatCompletionChunk],
         strip_emojis: bool,
+        tool_call_extra_content: dict[str, Any] | None = None,
     ) -> AsyncGenerator[conversation.AssistantContentDeltaDict, None]:
         """Transform a streaming OpenAI response to ChatLog format."""
         new_msg = True
@@ -473,16 +521,12 @@ class LocalAiEntity(Entity):
                     )
                     tool_key = tool_call_id + tool_call_name
 
-                    if tool_key not in pending_tool_calls:
-                        pending_tool_calls[tool_key] = {
-                            "id": tool_call_id,
-                            "name": tool_call.function.name,
-                            "args": tool_call.function.arguments or "",
-                        }
-                    else:
-                        pending_tool_calls[tool_key]["args"] += (
-                            tool_call.function.arguments or ""
-                        )
+                    self._accumulate_tool_call_delta(
+                        pending_tool_calls,
+                        tool_key,
+                        tool_call_id,
+                        tool_call,
+                    )
 
             # Handle reasoning_content field (used by reasoning models via OpenAI-compatible APIs)
             # Naming for this field varies. See https://github.com/vllm-project/vllm/issues/27755
@@ -590,6 +634,14 @@ class LocalAiEntity(Entity):
 
                     _LOGGER.debug("Calling tools: %s", parsed_tool_calls)
                     chunk["tool_calls"] = parsed_tool_calls
+                    if tool_call_extra_content is not None:
+                        # llm.ToolInput has no field for this, so it's tracked
+                        # separately and re-attached in
+                        # _convert_content_to_chat_message by tool_call.id
+                        self._collect_tool_call_extra_content(
+                            pending_tool_calls,
+                            tool_call_extra_content,
+                        )
                     pending_tool_calls.clear()
 
             if (
@@ -638,11 +690,31 @@ class LocalAiEntity(Entity):
                 for tool in chat_log.llm_api.tools
             ]
 
+        # Drop cached extra_content for tool calls no longer present in this
+        # chat_log so the entity-scoped cache doesn't grow across unrelated
+        # conversations over the entity's lifetime.
+        live_tool_call_ids = {
+            tool_call.id
+            for content in chat_log.content
+            if isinstance(content, conversation.AssistantContent) and content.tool_calls
+            for tool_call in content.tool_calls
+        }
+        self._tool_call_extra_content = {
+            tool_call_id: extra_content
+            for tool_call_id, extra_content in self._tool_call_extra_content.items()
+            if tool_call_id in live_tool_call_ids
+        }
+
         messages = self._trim_history(
             [
                 m
                 for content in chat_log.content
-                if (m := await self._convert_content_to_chat_message(content))
+                if (
+                    m := await self._convert_content_to_chat_message(
+                        content,
+                        tool_call_extra_content=self._tool_call_extra_content,
+                    )
+                )
             ],
             max_message_history,
         )
@@ -713,6 +785,12 @@ class LocalAiEntity(Entity):
                     stream=True,
                 )
 
+                # self._tool_call_extra_content carries provider-specific
+                # tool-call metadata (e.g. Gemini 3.x thought_signature) from
+                # the stream that produced a tool call to the request that
+                # echoes it back. It is entity-scoped, not local to this
+                # call, so it also survives into later conversation turns
+                # (see the GC + reuse in _async_handle_chat_log).
                 model_args["messages"].extend(
                     [
                         msg
@@ -721,9 +799,15 @@ class LocalAiEntity(Entity):
                             self._transform_stream(
                                 stream=result_stream,
                                 strip_emojis=strip_emojis,
+                                tool_call_extra_content=self._tool_call_extra_content,
                             ),
                         )
-                        if (msg := await self._convert_content_to_chat_message(content))
+                        if (
+                            msg := await self._convert_content_to_chat_message(
+                                content,
+                                tool_call_extra_content=self._tool_call_extra_content,
+                            )
+                        )
                     ],
                 )
             except openai.OpenAIError as err:

--- a/tests/entities/test_entity.py
+++ b/tests/entities/test_entity.py
@@ -20,6 +20,9 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCallFunction,
 )
 
+from custom_components.local_openai.entities.llama_cpp import (
+    LlamaCppConversationEntity,
+)
 from custom_components.local_openai.entity import MAX_TOOL_ITERATIONS
 from custom_components.local_openai.conversation import LocalAiConversationEntity
 
@@ -161,6 +164,192 @@ class TestRunAgentLoopSingleIteration:
 
         assert call_count == MAX_TOOL_ITERATIONS
         assert len(model_args["messages"]) == MAX_TOOL_ITERATIONS
+
+
+class TestRunAgentLoopToolCallExtraContent:
+    """Test that provider-specific tool-call metadata survives a round trip."""
+
+    async def test_extra_content_echoed_on_follow_up_request(
+        self,
+        hass: HomeAssistant,
+        mock_conversation_entity: conversation.ConversationAgent,
+    ):
+        """Test a tool call's extra_content is echoed back on the next request."""
+        entity = mock_conversation_entity
+
+        tool_call = ChoiceDeltaToolCall(
+            index=0,
+            id="call_1",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(
+                name="test_fn",
+                arguments='{"arg": "val"}',
+            ),
+            extra_content={"google": {"thought_signature": "sig123"}},
+        )
+        chunk = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(role="assistant", tool_calls=[tool_call]),
+                    finish_reason="tool_calls",
+                )
+            ],
+        )
+
+        captured_messages = []
+
+        async def mock_stream():
+            yield chunk
+
+        def create_side_effect(**kwargs) -> AsyncGenerator[ChatCompletionChunk, None]:
+            captured_messages.append(list(kwargs["messages"]))
+            return mock_stream()
+
+        entity.entry.runtime_data.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect
+        )
+
+        async def stream_content(
+            entity_id, stream_gen
+        ) -> AsyncGenerator[MockContent, None]:
+            tool_calls = None
+            async for delta in stream_gen:
+                if delta.get("tool_calls"):
+                    tool_calls = delta["tool_calls"]
+            yield MockContent(content="", tool_calls=tool_calls)
+
+        chat_log = MagicMock(spec=conversation.ChatLog)
+        chat_log.async_add_delta_content_stream = stream_content
+        chat_log.unresponded_tool_results = [MagicMock()]
+
+        model_args = {"model": "test", "messages": []}
+
+        await entity._run_agent_loop(
+            entity.entry.runtime_data,
+            model_args,
+            chat_log,
+            strip_emojis=False,
+        )
+
+        assert len(captured_messages) == MAX_TOOL_ITERATIONS
+        second_call_messages = captured_messages[1]
+        assistant_messages = [
+            m for m in second_call_messages if m.get("role") == "assistant"
+        ]
+        assert len(assistant_messages) == 1
+        tool_call_param = assistant_messages[0]["tool_calls"][0]
+        assert tool_call_param["extra_content"] == {
+            "google": {"thought_signature": "sig123"}
+        }
+
+    async def test_tool_call_iteration_on_llamacpp_override(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_llamacpp,
+        mock_conversation_subentry_llamacpp,
+    ):
+        """Test the LlamaCppMixin override forwards tool_call_extra_content."""
+        entity = LlamaCppConversationEntity(
+            mock_config_entry_llamacpp,
+            mock_conversation_subentry_llamacpp,
+        )
+        entity.hass = hass
+
+        tool_call = ChoiceDeltaToolCall(
+            index=0,
+            id="call_1",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="test_fn", arguments="{}"),
+        )
+        chunk = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(role="assistant", tool_calls=[tool_call]),
+                )
+            ],
+        )
+
+        def create_side_effect(**kwargs) -> AsyncGenerator[ChatCompletionChunk, None]:
+            async def mock_stream():
+                yield chunk
+
+            return mock_stream()
+
+        entity.entry.runtime_data.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect
+        )
+
+        async def stream_content(
+            entity_id, stream_gen
+        ) -> AsyncGenerator[MockContent, None]:
+            yield MockContent(content="")
+
+        chat_log = MagicMock(spec=conversation.ChatLog)
+        chat_log.async_add_delta_content_stream = stream_content
+        chat_log.unresponded_tool_results = [MagicMock()]
+
+        model_args = {"model": "test", "messages": []}
+
+        await entity._run_agent_loop(
+            entity.entry.runtime_data,
+            model_args,
+            chat_log,
+            strip_emojis=False,
+        )
+
+        assert len(model_args["messages"]) == MAX_TOOL_ITERATIONS
+
+
+class TestToolCallExtraContentSurvivesAcrossTurns:
+    """Test that extra_content is re-attached on a LATER turn, not just within
+    the same _run_agent_loop call. This is what the entity-scoped
+    self._tool_call_extra_content cache (as opposed to a fresh dict per
+    _run_agent_loop invocation) exists for."""
+
+    async def test_historical_tool_call_gets_extra_content_from_a_prior_turn(
+        self,
+        hass: HomeAssistant,
+        mock_conversation_entity: conversation.ConversationAgent,
+    ):
+        """A tool call recorded on entity._tool_call_extra_content by an
+        earlier turn is still re-attached when that call shows up as history
+        in a later, separate call to _convert_content_to_chat_message."""
+        entity = mock_conversation_entity
+
+        # Simulates what turn 1's _run_agent_loop would have populated.
+        entity._tool_call_extra_content["call_1"] = {
+            "google": {"thought_signature": "sig123"}
+        }
+
+        # Simulates turn 2 rebuilding history from chat_log.content, the way
+        # _async_handle_chat_log does, well after turn 1's _run_agent_loop
+        # (and any of ITS local state) has already returned.
+        historical_content = MockContent(
+            content="",
+            tool_calls=[
+                llm.ToolInput(id="call_1", tool_name="test_fn", tool_args={}),
+            ],
+        )
+
+        message = await entity._convert_content_to_chat_message(
+            historical_content,
+            tool_call_extra_content=entity._tool_call_extra_content,
+        )
+
+        assert message is not None
+        assert message["tool_calls"][0]["extra_content"] == {
+            "google": {"thought_signature": "sig123"}
+        }
 
 
 class TestRunAgentLoopErrorHandling:


### PR DESCRIPTION
Gemini 3.x requires each tool call's `extra_content.google.thought_signature` to be echoed back verbatim on the next request. `_transform_stream` only kept `id`/`name`/`args` when accumulating a streamed tool-call delta, and `_convert_content_to_chat_message` rebuilt the outgoing `tool_call` param from scratch with no reference to `extra_content`. The field is dropped in both places before the follow-up request goes out, and Gemini rejects that request with `400 INVALID_ARGUMENT` exactly as reported.

The fix tracks each tool call's `extra_content` alongside `id`/`name`/`args` while accumulating stream deltas, hands it out by `tool_call.id` once a message finishes, and re-attaches it when building the next request's assistant message, only when the incoming tool call actually carried it. Non-Gemini providers never populate the field, so this is a no-op for them, matching the caution skye-harris raised in the #60 thread about unexpected fields breaking other backends.

`_convert_content_to_chat_message` gained a parameter for this, so its two other overrides (`LlamaCppMixin`, `DeepSeek`) needed to accept and forward it too. Without that, every llama.cpp or DeepSeek tool-call turn would raise `TypeError` as soon as `_run_agent_loop` called the override with the new keyword argument.

Verified in a clean `python:3.13-slim` container with the repo's own `pytest-homeassistant-custom-component` suite:
- New regression test (`TestRunAgentLoopToolCallExtraContent`) fails on `master` (`KeyError: 'extra_content'`) and passes on this branch.
- A second new test drives `_run_agent_loop` through `LlamaCppConversationEntity`; it raises `TypeError` without the override changes above and passes with them.
- Full suite: 105 passed on `master`, 107 passed on this branch (the two new tests), no other change.
- `ruff check`/`ruff format --check` clean on the changed files.
- Not checked: a live call against Gemini's actual endpoint (no API key in this environment); the fix is verified against the OpenAI SDK's request-building code, not a live 400 response.

Fixes #101
