### PR TITLE
Handle some tool failures

### DIFF
--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -554,7 +554,6 @@ class LocalAiEntity(Entity):
                     parsed_tool_calls: list[llm.ToolInput] = []
                     for tool_call in pending_tool_calls.values():
                         try:
-                            tool_call["args"] = "{invalid json"
                             args = (
                                 json.loads(tool_call["args"])
                                 if tool_call["args"]

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -84,6 +84,17 @@ _SUPPORTS_THINKING = "thinking_content" in getattr(
 )
 
 
+class ToolArgsException(Exception):
+    tool_id: str
+    name: str
+    args: str | None
+
+    def __init__(self, tool_id: str, name: str, args: str | None):
+        self.tool_id = tool_id
+        self.name = name
+        self.args = args
+
+
 def _remove_unsupported_keys_from_tool_schema(schema: dict[str, Any]) -> None:
     """Remove keys not supported in the tool schema."""
     for key in ("allOf", "anyOf", "oneOf"):
@@ -462,18 +473,24 @@ class LocalAiEntity(Entity):
                     pass
 
                 if pending_tool_calls:
-                    chunk["tool_calls"] = [
-                        llm.ToolInput(
-                            id=tool_call["id"],
-                            tool_name=tool_call["name"],
-                            tool_args=json.loads(tool_call["args"])
-                            if tool_call["args"]
-                            else {},
-                        )
-                        for key, tool_call in pending_tool_calls.items()
-                    ]
-                    _LOGGER.debug("Calling tools: %s", pending_tool_calls)
+                    chunk["tool_calls"] = []
+                    for key, tool_call in pending_tool_calls.items():
+                        try:
+                            chunk["tool_calls"].append(
+                                llm.ToolInput(
+                                    id=tool_call["id"],
+                                    tool_name=tool_call["name"],
+                                    tool_args=json.loads(tool_call["args"])
+                                    if tool_call["args"]
+                                    else {},
+                                )
+                            )
+                        except Exception:
+                            _LOGGER.exception("Failed to parse tool call: %s", tool_call)
+                            raise ToolArgsException(tool_call["id"], tool_call["name"], tool_call["args"])
+                        _LOGGER.debug("Calling tools: %s", pending_tool_calls)
                     pending_tool_calls.clear()
+
 
             if (
                 seen_visible

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -84,18 +84,6 @@ _SUPPORTS_THINKING = "thinking_content" in getattr(
 )
 
 
-class ToolArgsException(Exception):
-    tool_id: str
-    name: str
-    tool_args: str | None
-
-    def __init__(self, tool_id: str, name: str, tool_args: str | None):
-        self.tool_id = tool_id
-        self.name = name
-        self.tool_args = tool_args
-        super().__init__(f"Tool '{name}' failed to parse arguments: {tool_args}")
-
-
 def _remove_unsupported_keys_from_tool_schema(schema: dict[str, Any]) -> None:
     """Remove keys not supported in the tool schema."""
     for key in ("allOf", "anyOf", "oneOf"):
@@ -439,7 +427,7 @@ class LocalAiEntity(Entity):
                     ]
         return messages, tools
 
-    async def _transform_stream(
+    async def _transform_stream(  # noqa: C901 todo: will break this up
         self,
         stream: AsyncStream[ChatCompletionChunk],
         strip_emojis: bool,
@@ -553,6 +541,7 @@ class LocalAiEntity(Entity):
                 if seen_visible:
                     chunk["content"] = content
 
+            tool_error_deltas: list[dict] = []
             if choice.finish_reason:
                 try:
                     # Retrieve timings from llamacpp responses, if available
@@ -562,24 +551,47 @@ class LocalAiEntity(Entity):
                     pass
 
                 if pending_tool_calls:
-                    chunk["tool_calls"] = []
-                    for key, tool_call in pending_tool_calls.items():
+                    parsed_tool_calls: list[llm.ToolInput] = []
+                    for tool_call in pending_tool_calls.values():
                         try:
-                            chunk["tool_calls"].append(
+                            tool_call["args"] = "{invalid json"
+                            args = (
+                                json.loads(tool_call["args"])
+                                if tool_call["args"]
+                                else {}
+                            )
+                            parsed_tool_calls.append(
                                 llm.ToolInput(
                                     id=tool_call["id"],
                                     tool_name=tool_call["name"],
-                                    tool_args=json.loads(tool_call["args"])
-                                    if tool_call["args"]
-                                    else {},
+                                    tool_args=args,
                                 )
                             )
-                        except Exception:
-                            _LOGGER.exception("Failed to parse tool call: %s", tool_call)
-                            raise ToolArgsException(tool_call["id"], tool_call["name"], tool_call["args"])
-                        _LOGGER.debug("Calling tools: %s", pending_tool_calls)
-                    pending_tool_calls.clear()
+                        except json.JSONDecodeError:  # noqa: PERF203
+                            parsed_tool_calls.append(
+                                llm.ToolInput(
+                                    id=tool_call["id"],
+                                    tool_name=tool_call["name"],
+                                    tool_args={
+                                        "json_decode_failure": tool_call["args"]
+                                    },
+                                    external=True,
+                                )
+                            )
+                            tool_error_deltas.append(
+                                {
+                                    "role": "tool_result",
+                                    "tool_call_id": tool_call["id"],
+                                    "tool_name": tool_call["name"],
+                                    "tool_result": {
+                                        "error": f"Failed to parse tool arguments: {tool_call['args']}\n\nCheck your JSON and try again.",
+                                    },
+                                }
+                            )
 
+                    _LOGGER.debug("Calling tools: %s", parsed_tool_calls)
+                    chunk["tool_calls"] = parsed_tool_calls
+                    pending_tool_calls.clear()
 
             if (
                 seen_visible
@@ -588,6 +600,8 @@ class LocalAiEntity(Entity):
                 or chunk.get("thinking_content")
             ):
                 yield chunk
+                for error_delta in tool_error_deltas:
+                    yield error_delta
 
     async def _async_handle_chat_log(
         self,
@@ -686,21 +700,20 @@ class LocalAiEntity(Entity):
         strip_emojis: bool,
     ) -> None:
         """Run the LLM agent loop with tool call iteration."""
-        for _iteration in range(MAX_TOOL_ITERATIONS):
-            if _iteration == MAX_TOOL_ITERATIONS - 1:
-                messages = self._inject_stop_directive(messages)
+        for iteration in range(MAX_TOOL_ITERATIONS):
+            if iteration == MAX_TOOL_ITERATIONS - 1:
+                _LOGGER.debug("Max iterations reached, injecting stop message")
+                model_args["messages"] = self._inject_stop_directive(
+                    model_args["messages"]
+                )
+                model_args["tool_choice"] = "none"
 
             try:
                 result_stream = await client.chat.completions.create(
                     **model_args,
                     stream=True,
                 )
-            except openai.OpenAIError as err:
-                _LOGGER.exception("Error talking to API")
-                msg = "Error talking to API"
-                raise HomeAssistantError(msg) from err
 
-            try:
                 model_args["messages"].extend(
                     [
                         msg
@@ -714,9 +727,13 @@ class LocalAiEntity(Entity):
                         if (msg := await self._convert_content_to_chat_message(content))
                     ],
                 )
+            except openai.OpenAIError as err:
+                _LOGGER.exception("API server returned an error")
+                msg = "API server returned an error. Check the system logs for further details."
+                raise HomeAssistantError(msg) from err
             except Exception as err:
                 _LOGGER.exception("Error handling API response")
-                msg = "Error handling API response"
+                msg = "Error handling API response. Check the system logs for further details."
                 raise HomeAssistantError(msg) from err
 
             if not chat_log.unresponded_tool_results:

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -87,12 +87,13 @@ _SUPPORTS_THINKING = "thinking_content" in getattr(
 class ToolArgsException(Exception):
     tool_id: str
     name: str
-    args: str | None
+    tool_args: str | None
 
-    def __init__(self, tool_id: str, name: str, args: str | None):
+    def __init__(self, tool_id: str, name: str, tool_args: str | None):
         self.tool_id = tool_id
         self.name = name
-        self.args = args
+        self.tool_args = tool_args
+        super().__init__(f"Tool '{name}' failed to parse arguments: {tool_args}")
 
 
 def _remove_unsupported_keys_from_tool_schema(schema: dict[str, Any]) -> None:
@@ -659,6 +660,9 @@ class LocalAiEntity(Entity):
         client = self.entry.runtime_data
 
         for _iteration in range(MAX_TOOL_ITERATIONS):
+            if _iteration == MAX_TOOL_ITERATIONS - 1:
+                messages = self._inject_stop_directive(messages)
+
             try:
                 result_stream = await client.chat.completions.create(
                     **model_args,
@@ -690,6 +694,23 @@ class LocalAiEntity(Entity):
 
             if not chat_log.unresponded_tool_results:
                 break
+
+    @staticmethod
+    def _inject_stop_directive(messages: list) -> list:
+        """Append a stop-directive to the last tool result if present."""
+        if not messages:
+            return messages
+        last_msg = messages[-1]
+        if last_msg.get("role") != "tool":
+            return messages
+        directive = (
+            "\n\nYou have reached the maximum number of tool call iterations. "
+            "You must now provide your final response directly to the user "
+            "without calling any more tools."
+        )
+        existing_content = last_msg.get("content", "")
+        last_msg["content"] = existing_content + directive
+        return messages
 
     @staticmethod
     def _trim_history(messages: list, max_messages: int) -> list:

--- a/tests/entities/test_entity.py
+++ b/tests/entities/test_entity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock
 
 import openai
@@ -10,6 +11,7 @@ import pytest
 from homeassistant.components import conversation
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import llm
 from openai.types.chat import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import (
     Choice,
@@ -19,6 +21,7 @@ from openai.types.chat.chat_completion_chunk import (
 )
 
 from custom_components.local_openai.entity import MAX_TOOL_ITERATIONS
+from custom_components.local_openai.conversation import LocalAiConversationEntity
 
 
 class MockContent(conversation.AssistantContent):
@@ -73,6 +76,7 @@ class TestRunAgentLoopSingleIteration:
         chat_log = MagicMock(spec=conversation.ChatLog)
         chat_log.async_add_delta_content_stream = stream_content
         chat_log.unresponded_tool_results = []
+        chat_log.content = []
 
         model_args = {"model": "test", "messages": []}
 
@@ -139,7 +143,12 @@ class TestRunAgentLoopSingleIteration:
 
         chat_log = MagicMock(spec=conversation.ChatLog)
         chat_log.async_add_delta_content_stream = stream_content
-        chat_log.unresponded_tool_results = [MagicMock()]
+        chat_log.content = []
+
+        def get_unresponded():
+            return chat_log.content and chat_log.content[-1].role == "tool_result"
+
+        chat_log.unresponded_tool_results = property(get_unresponded)
 
         model_args = {"model": "test", "messages": []}
 
@@ -174,7 +183,10 @@ class TestRunAgentLoopErrorHandling:
 
         model_args = {"model": "test", "messages": []}
 
-        with pytest.raises(HomeAssistantError, match="Error talking to API"):
+        with pytest.raises(
+            HomeAssistantError,
+            match="API server returned an error. Check the system logs for further details.",
+        ):
             await entity._run_agent_loop(
                 entity.entry.runtime_data,
                 model_args,
@@ -218,10 +230,342 @@ class TestRunAgentLoopErrorHandling:
 
         model_args = {"model": "test", "messages": []}
 
-        with pytest.raises(HomeAssistantError, match="Error handling API response"):
+        with pytest.raises(
+            HomeAssistantError,
+            match="Error handling API response. Check the system logs for further details.",
+        ):
             await entity._run_agent_loop(
                 entity.entry.runtime_data,
                 model_args,
                 chat_log,
                 strip_emojis=False,
             )
+
+    async def test_tool_args_decode_failure_injects_error_result(
+        self,
+        hass: HomeAssistant,
+        mock_conversation_entity: conversation.ConversationAgent,
+    ):
+        """Test malformed tool call arguments injects error result and continues loop."""
+        entity = mock_conversation_entity
+
+        tool_call = ChoiceDeltaToolCall(
+            index=0,
+            id="call_1",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(
+                name="test_fn",
+                arguments='{"arg": broken-json',
+            ),
+        )
+        chunk = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(
+                        role="assistant",
+                        tool_calls=[tool_call],
+                    ),
+                )
+            ],
+            usage=None,
+        )
+
+        # Add finish_reason to trigger the tool call parsing
+        chunk_with_finish = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=None,
+        )
+
+        mock_stream = MagicMock()
+
+        async def async_gen():
+            for item in [chunk, chunk_with_finish]:
+                yield item
+
+        mock_stream.__aiter__ = MagicMock(return_value=async_gen())
+        entity.entry.runtime_data.chat.completions.create = AsyncMock(
+            return_value=mock_stream
+        )
+
+        async def stream_content(
+            entity_id, stream_gen
+        ) -> AsyncGenerator[
+            conversation.AssistantContent | conversation.ToolResultContent, None
+        ]:
+            assistant = MockContent(
+                content="",
+                tool_calls=[
+                    llm.ToolInput(
+                        id="call_1",
+                        tool_name="test_fn",
+                        tool_args={"json_decode_failure": '{"arg": broken-json'},
+                        external=True,
+                    )
+                ],
+            )
+            yield assistant
+            chat_log.content.append(assistant)
+            error_content = conversation.ToolResultContent(
+                agent_id="test_agent",
+                tool_call_id="call_1",
+                tool_name="test_fn",
+                tool_result={
+                    "error": 'Failed to parse tool arguments: {"arg": broken-json\n\nCheck your JSON and try again.',
+                },
+            )
+            yield error_content
+            chat_log.content.append(error_content)
+
+        chat_log = MagicMock(spec=conversation.ChatLog)
+        chat_log.async_add_delta_content_stream = stream_content
+        chat_log.content = []
+
+        def get_unresponded():
+            return chat_log.content and chat_log.content[-1].role == "tool_result"
+
+        chat_log.unresponded_tool_results = property(get_unresponded)
+
+        call_count = 0
+
+        def create_side_effect(**kwargs) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            mock_stream = MagicMock()
+            mock_stream.__aiter__ = MagicMock(return_value=async_gen())
+            return mock_stream
+
+        entity.entry.runtime_data.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect
+        )
+
+        model_args = {"model": "test", "messages": []}
+
+        # Should not raise - error is injected and loop continues
+        await entity._run_agent_loop(
+            entity.entry.runtime_data,
+            model_args,
+            chat_log,
+            strip_emojis=False,
+        )
+
+        # Verify the loop ran all iterations (tool error keeps it going)
+        assert call_count == MAX_TOOL_ITERATIONS
+        # Verify tool error result was injected into chat log in each iteration
+        assert len(chat_log.content) == MAX_TOOL_ITERATIONS * 2
+        for i in range(0, len(chat_log.content), 2):
+            assistant_content = chat_log.content[i]
+            assert isinstance(assistant_content, conversation.AssistantContent)
+            assert assistant_content.tool_calls is not None
+            assert len(assistant_content.tool_calls) == 1
+            assert assistant_content.tool_calls[0].external is True
+            error_content = chat_log.content[i + 1]
+            assert isinstance(error_content, conversation.ToolResultContent)
+            assert error_content.tool_name == "test_fn"
+            assert error_content.tool_call_id == "call_1"
+            assert (
+                "Failed to parse tool arguments" in error_content.tool_result["error"]
+            )
+
+    async def test_stop_directive_injected_on_final_iteration(
+        self,
+        hass: HomeAssistant,
+        mock_conversation_entity: conversation.ConversationAgent,
+    ):
+        """Test stop directive is injected and tool_choice set to none on the final iteration."""
+        entity = mock_conversation_entity
+
+        tool_call = ChoiceDeltaToolCall(
+            index=0,
+            id="call_1",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(
+                name="test_fn",
+                arguments='{"arg": "val"}',
+            ),
+        )
+        chunk = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(
+                        role="assistant",
+                        tool_calls=[tool_call],
+                    ),
+                )
+            ],
+        )
+
+        chunk_with_finish = ChatCompletionChunk(
+            id="test",
+            created=0,
+            model="test",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=None,
+        )
+
+        call_count = 0
+        captured_kwargs: list[dict] = []
+
+        def create_side_effect(**kwargs) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            captured_kwargs.append(deepcopy(kwargs))
+            if call_count == MAX_TOOL_ITERATIONS:
+                last_msg = kwargs["messages"][-1]
+                assert "maximum number of tool call iterations" in last_msg.get(
+                    "content", ""
+                ), (
+                    f"Iteration {call_count}: last_msg content = {last_msg.get('content')!r}"
+                )
+            mock_stream = MagicMock()
+            mock_stream.__aiter__ = MagicMock(
+                return_value=iter([chunk, chunk_with_finish])
+            )
+            return mock_stream
+
+        entity.entry.runtime_data.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect
+        )
+
+        async def stream_content(
+            entity_id, stream_gen
+        ) -> AsyncGenerator[
+            conversation.AssistantContent | conversation.ToolResultContent, None
+        ]:
+            assistant = MockContent(
+                content="",
+                tool_calls=[
+                    llm.ToolInput(
+                        id="call_1",
+                        tool_name="test_fn",
+                        tool_args={"arg": "val"},
+                        external=True,
+                    )
+                ],
+            )
+            yield assistant
+            chat_log.content.append(assistant)
+            error_content = conversation.ToolResultContent(
+                agent_id="test_agent",
+                tool_call_id="call_1",
+                tool_name="test_fn",
+                tool_result={"error": "tool failed"},
+            )
+            yield error_content
+            chat_log.content.append(error_content)
+
+        chat_log = MagicMock(spec=conversation.ChatLog)
+        chat_log.async_add_delta_content_stream = stream_content
+        chat_log.content = []
+
+        def get_unresponded():
+            return chat_log.content and chat_log.content[-1].role == "tool_result"
+
+        chat_log.unresponded_tool_results = property(get_unresponded)
+
+        model_args = {"model": "test", "messages": []}
+
+        await entity._run_agent_loop(
+            entity.entry.runtime_data,
+            model_args,
+            chat_log,
+            strip_emojis=False,
+        )
+
+        assert call_count == MAX_TOOL_ITERATIONS
+
+        last_call = captured_kwargs[-1]
+        assert call_count == MAX_TOOL_ITERATIONS, (
+            f"Expected {MAX_TOOL_ITERATIONS} calls, got {call_count}"
+        )
+        assert last_call["tool_choice"] == "none"
+
+        last_message = last_call["messages"][-1]
+        assert last_message["role"] == "tool"
+        directive = (
+            "\n\nYou have reached the maximum number of tool call iterations. "
+            "You must now provide your final response directly to the user "
+            "without calling any more tools."
+        )
+        assert last_message["content"] == '{"error": "tool failed"}' + directive, (
+            f"Got: {last_message['content']!r}"
+        )
+
+        for i in range(MAX_TOOL_ITERATIONS - 1):
+            assert captured_kwargs[i].get("tool_choice") != "none"
+
+
+class TestInjectStopDirective:
+    """Test _inject_stop_directive static method."""
+
+    def test_empty_messages(self):
+        """Test empty message list is returned unchanged."""
+        messages: list[dict] = []
+        result = LocalAiConversationEntity._inject_stop_directive(messages)
+        assert result == []
+
+    def test_no_last_tool_message(self):
+        """Test when last message is not a tool message, list is returned unchanged."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = LocalAiConversationEntity._inject_stop_directive(messages)
+        assert result == messages
+
+    def test_with_empty_tool_content(self):
+        """Test directive appended to empty tool content."""
+        messages = [
+            {"role": "tool", "tool_call_id": "1", "tool_name": "fn", "content": ""}
+        ]
+        result = LocalAiConversationEntity._inject_stop_directive(messages)
+        directive = (
+            "\n\nYou have reached the maximum number of tool call iterations. "
+            "You must now provide your final response directly to the user "
+            "without calling any more tools."
+        )
+        assert result[0]["content"] == directive
+
+    def test_with_existing_tool_content(self):
+        """Test directive appended after existing tool content."""
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "tool_name": "fn",
+                "content": "Previous result",
+            }
+        ]
+        result = LocalAiConversationEntity._inject_stop_directive(messages)
+        directive = (
+            "\n\nYou have reached the maximum number of tool call iterations. "
+            "You must now provide your final response directly to the user "
+            "without calling any more tools."
+        )
+        assert result[0]["content"] == "Previous result" + directive


### PR DESCRIPTION
- Catch tool arg decode failures, mark as "external" tools so that HA wont try to run them, and emit a tool result out with the decode failure message and a retry instruction for the model
- If we reach the tool-call iteration limit, on our last iteration, disable further tool-calls and inject an instruction into the end of the prior tool result message so that the model understands we are on our final iteration, and to respond to the user