### PR TITLE
Bugfix extra body args

### DIFF
--- a/custom_components/local_openai/entities/deepseek.py
+++ b/custom_components/local_openai/entities/deepseek.py
@@ -24,7 +24,6 @@ from custom_components.local_openai.conversation import LocalAiConversationEntit
 if TYPE_CHECKING:
     from types import MappingProxyType
 
-    from homeassistant.config_entries import ConfigSubentry
     from openai.types.chat import ChatCompletionMessageParam
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,63 +51,47 @@ def get_conversation_config_schema() -> dict:
     return _get_deepseek_schema()
 
 
-def _deepseek_extra_body_args(options: MappingProxyType[str, Any]) -> dict:
-    """Handle extra_body args for DeepSeek."""
-    opts = options.get(CONF_DEEPSEEK_CONFIG, {})
-    reasoning_effort = opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
-    if reasoning_effort:
-        return {
-            "thinking": {"type": "enabled"},
-            "reasoning_effort": reasoning_effort,
-        }
-    return {"thinking": {"type": "disabled"}}
+def get_ai_task_config_schema() -> dict:
+    """Return AI task config schema fields for DeepSeek."""
+    return _get_deepseek_schema()
 
 
-async def _deepseek_augment_content_message(
-    subentry: ConfigSubentry,
-    param: ChatCompletionMessageParam | None,
-    content: conversation.Content,
-) -> ChatCompletionMessageParam | None:
-    """If thinking is enabled, and the message has thinking content, pass this back in the request."""
-    opts = subentry.data.get(CONF_DEEPSEEK_CONFIG, {})
+class DeepSeekMixin:
+    """Mixin for DeepSeek entities with shared logic."""
 
-    if (
-        opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
-        and isinstance(content, conversation.AssistantContent)
-        and hasattr(content, "thinking_content")
-        and content.thinking_content
-    ):
-        param["reasoning_content"] = content.thinking_content
-    return param
+    def _get_extra_body_args(self, options: MappingProxyType[str, Any]) -> dict:
+        """Handle extra_body args for DeepSeek."""
+        extra = super()._get_extra_body_args(options)
+        opts = options.get(CONF_DEEPSEEK_CONFIG, {})
+        reasoning_effort = opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
+        if reasoning_effort:
+            extra["thinking"] = {"type": "enabled"}
+            extra["reasoning_effort"] = reasoning_effort
+        else:
+            extra["thinking"] = {"type": "disabled"}
+        return extra
+
+    async def _convert_content_to_chat_message(
+        self,
+        content: conversation.Content,
+    ) -> ChatCompletionMessageParam | None:
+        """If thinking is enabled, pass prior thinking content back in the request."""
+        param = await super()._convert_content_to_chat_message(content)
+        opts = self.subentry.data.get(CONF_DEEPSEEK_CONFIG, {})
+
+        if (
+            opts.get(CONF_DEEPSEEK_REASONING_EFFORT)
+            and isinstance(content, conversation.AssistantContent)
+            and hasattr(content, "thinking_content")
+            and content.thinking_content
+        ):
+            param["reasoning_content"] = content.thinking_content
+        return param
 
 
-class DeepSeekConversationEntity(LocalAiConversationEntity):
+class DeepSeekConversationEntity(DeepSeekMixin, LocalAiConversationEntity):
     """Conversation agent for DeepSeek Cloud servers."""
 
-    def _get_extra_body_args(self, options: MappingProxyType[str, Any]) -> dict:
-        """Handle extra arguments for DeepSeek."""
-        return _deepseek_extra_body_args(options)
 
-    async def _convert_content_to_chat_message(
-        self,
-        content: conversation.Content,
-    ) -> ChatCompletionMessageParam | None:
-        """Handle chat message conversion for DeepSeek."""
-        param = await super()._convert_content_to_chat_message(content)
-        return await _deepseek_augment_content_message(self.subentry, param, content)
-
-
-class DeepSeekAITaskEntity(LocalAITaskEntity):
+class DeepSeekAITaskEntity(DeepSeekMixin, LocalAITaskEntity):
     """AI Task entity for DeepSeek Cloud servers."""
-
-    def _get_extra_body_args(self, options: MappingProxyType[str, Any]) -> dict:
-        """Handle extra arguments for DeepSeek."""
-        return _deepseek_extra_body_args(options)
-
-    async def _convert_content_to_chat_message(
-        self,
-        content: conversation.Content,
-    ) -> ChatCompletionMessageParam | None:
-        """Handle chat message conversion for DeepSeek."""
-        param = await super()._convert_content_to_chat_message(content)
-        return await _deepseek_augment_content_message(self.subentry, param, content)

--- a/custom_components/local_openai/entities/llama_cpp.py
+++ b/custom_components/local_openai/entities/llama_cpp.py
@@ -126,15 +126,17 @@ class LlamaCppMixin:
     ) -> dict:
         """Handle extra_body args for llama.cpp."""
         opts = options.get(CONF_LLAMACPP_CONFIG, {})
-        extras: dict = {}
+        extras = super()._get_extra_body_args(options)
 
         id_slot = opts.get(CONF_LLAMACPP_ID_SLOT)
         if id_slot is not None:
             extras["id_slot"] = int(id_slot)
 
-        extras["chat_template_kwargs"] = {
-            "enable_thinking": bool(opts.get(CONF_LLAMACPP_ENABLE_THINKING, False)),
-        }
+        chat_template_kwargs = extras.get("chat_template_kwargs", {})
+        chat_template_kwargs["enable_thinking"] = bool(
+            opts.get(CONF_LLAMACPP_ENABLE_THINKING, False)
+        )
+        extras["chat_template_kwargs"] = chat_template_kwargs
 
         sampling_params = [
             (CONF_LLAMACPP_TOP_P, float, "top_p"),

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -24,7 +24,7 @@
             }
           },
           "weaviate_options": {
-            "name": "Weaviate configuration",
+            "name": "Weaviate Configuration",
             "description": "Query a Weaviate vector database with user messages and augment the generation with semantically-similar results",
             "data": {
               "weaviate_host": "Weaviate server address",
@@ -60,7 +60,7 @@
             }
           },
           "weaviate_options": {
-            "name": "Weaviate configuration",
+            "name": "Weaviate Configuration",
             "data": {
               "weaviate_host": "Weaviate server address",
               "weaviate_api_key": "API key"
@@ -155,7 +155,7 @@
               }
             },
             "weaviate_options": {
-              "name": "Weaviate configuration",
+              "name": "Weaviate Configuration",
               "data": {
                 "weaviate_class_name": "Weaviate object class name",
                 "weaviate_max_results": "Maximum number of results",
@@ -238,7 +238,7 @@
               }
             },
             "weaviate_options": {
-              "name": "Weaviate configuration",
+              "name": "Weaviate Configuration",
               "data": {
                 "weaviate_class_name": "Weaviate object class name",
                 "weaviate_max_results": "Maximum number of results",

--- a/tests/entities/deepseek/test_deepseek_model_args.py
+++ b/tests/entities/deepseek/test_deepseek_model_args.py
@@ -1,0 +1,65 @@
+"""Unit tests for _get_extra_body_args instance method."""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.local_openai.const import (
+    CONF_DEEPSEEK_CONFIG,
+    CONF_DEEPSEEK_REASONING_EFFORT,
+)
+from custom_components.local_openai.entities.deepseek import DeepSeekMixin
+
+# Stands in for LocalAiEntity, whose _get_extra_body_args builds chat_template_kwargs
+BASE_EXTRA_BODY_ARGS = {
+    "chat_template_kwargs": {"enable_thinking": True, "hello": "world"}
+}
+
+
+class _StubBase:
+    def _get_extra_body_args(self, options: dict) -> dict:
+        return dict(BASE_EXTRA_BODY_ARGS)
+
+
+class _StubDeepSeekEntity(DeepSeekMixin, _StubBase):
+    pass
+
+
+class TestDeepSeekExtraBodyArgs:
+    """Tests for _get_extra_body_args instance method."""
+
+    def test_super_call_retained(self) -> None:
+        """Test that data from the super call is retained in the result."""
+        result = _StubDeepSeekEntity()._get_extra_body_args({})
+        assert result["chat_template_kwargs"]["hello"] == "world"
+        assert result["chat_template_kwargs"]["enable_thinking"] is True
+
+    @pytest.mark.parametrize(
+        "options,extra_expected",
+        [
+            # reasoning_effort set -> thinking enabled
+            (
+                {CONF_DEEPSEEK_CONFIG: {CONF_DEEPSEEK_REASONING_EFFORT: "high"}},
+                {"thinking": {"type": "enabled"}, "reasoning_effort": "high"},
+            ),
+            # reasoning_effort set to max
+            (
+                {CONF_DEEPSEEK_CONFIG: {CONF_DEEPSEEK_REASONING_EFFORT: "max"}},
+                {"thinking": {"type": "enabled"}, "reasoning_effort": "max"},
+            ),
+            # Empty config -> thinking disabled, no reasoning_effort
+            ({CONF_DEEPSEEK_CONFIG: {}}, {"thinking": {"type": "disabled"}}),
+            # None config -> thinking disabled, no reasoning_effort
+            ({}, {"thinking": {"type": "disabled"}}),
+            # reasoning_effort at top level, not in config section -> ignored
+            (
+                {CONF_DEEPSEEK_REASONING_EFFORT: "high"},
+                {"thinking": {"type": "disabled"}},
+            ),
+        ],
+    )
+    def test_deepseek_extra_body_args(
+        self, options: dict, extra_expected: dict
+    ) -> None:
+        """Test extra body arguments generation with various configurations."""
+        result = _StubDeepSeekEntity()._get_extra_body_args(options)
+        assert result == BASE_EXTRA_BODY_ARGS | extra_expected

--- a/tests/entities/llama_cpp/test_llama_cpp_model_args.py
+++ b/tests/entities/llama_cpp/test_llama_cpp_model_args.py
@@ -16,9 +16,38 @@ from custom_components.local_openai.const import (
 )
 from custom_components.local_openai.entities.llama_cpp import LlamaCppMixin
 
+BASE_EXTRA_BODY_ARGS = {
+    "chat_template_kwargs": {"enable_thinking": False, "hello": "world"}
+}
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = {**result[key], **value}
+        else:
+            result[key] = value
+    return result
+
+
+class _StubBase:
+    def _get_extra_body_args(self, options: dict) -> dict:
+        return dict(BASE_EXTRA_BODY_ARGS)
+
+
+class _StubLlamaCppEntity(LlamaCppMixin, _StubBase):
+    pass
+
 
 class TestLlamaCppExtraBodyArgs:
     """Tests for _get_extra_body_args instance method."""
+
+    def test_super_call_retained(self) -> None:
+        """Test that data from the super call is retained in the result."""
+        result = _StubLlamaCppEntity()._get_extra_body_args({})
+        assert result["chat_template_kwargs"]["hello"] == "world"
+        assert result["chat_template_kwargs"]["enable_thinking"] is False
 
     @pytest.mark.parametrize(
         "options,expected",
@@ -62,10 +91,10 @@ class TestLlamaCppExtraBodyArgs:
             # No extra options
             (
                 {CONF_LLAMACPP_CONFIG: {}},
-                {"chat_template_kwargs": {"enable_thinking": False}},
+                {},
             ),
             # None config
-            ({}, {"chat_template_kwargs": {"enable_thinking": False}}),
+            ({}, {}),
             # Float id_slot converted to int
             (
                 {
@@ -96,8 +125,8 @@ class TestLlamaCppExtraBodyArgs:
     )
     def test_llama_cpp_extra_body_args(self, options: dict, expected: dict):
         """Test extra body arguments generation with various configurations."""
-        result = LlamaCppMixin()._get_extra_body_args(options)
-        assert result == expected
+        result = _StubLlamaCppEntity()._get_extra_body_args(options)
+        assert result == _deep_merge(BASE_EXTRA_BODY_ARGS, expected)
 
     @pytest.mark.parametrize(
         "options,expected",
@@ -151,8 +180,8 @@ class TestLlamaCppExtraBodyArgs:
         expected: dict,
     ):
         """Test extra_body with sampling parameters."""
-        result = LlamaCppMixin()._get_extra_body_args(options)
-        assert result == expected
+        result = _StubLlamaCppEntity()._get_extra_body_args(options)
+        assert result == _deep_merge(BASE_EXTRA_BODY_ARGS, expected)
 
     @pytest.mark.parametrize(
         "options,expected_sampling",
@@ -176,9 +205,9 @@ class TestLlamaCppExtraBodyArgs:
         expected_sampling: dict,
     ):
         """Test type conversion of sampling parameters in extra_body."""
-        result = LlamaCppMixin()._get_extra_body_args(options)
-        assert "chat_template_kwargs" in result
-        assert result["chat_template_kwargs"] == {"enable_thinking": False}
+        result = _StubLlamaCppEntity()._get_extra_body_args(options)
+        assert result["chat_template_kwargs"]["hello"] == "world"
+        assert result["chat_template_kwargs"]["enable_thinking"] is False
         for key, value in expected_sampling.items():
             assert result[key] == value
             assert isinstance(result[key], type(value))

--- a/tests/entities/vllm/test_vllm_model_args.py
+++ b/tests/entities/vllm/test_vllm_model_args.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from custom_components.local_openai.const import (
     CONF_VLLM_CONFIG,
     CONF_VLLM_THINKING_TOKEN_BUDGET,
@@ -11,7 +10,9 @@ from custom_components.local_openai.const import (
 from custom_components.local_openai.entities.vllm import VllmMixin
 
 # Stands in for LocalAiEntity, whose _get_extra_body_args builds chat_template_kwargs
-BASE_EXTRA_BODY_ARGS = {"chat_template_kwargs": {"enable_thinking": True}}
+BASE_EXTRA_BODY_ARGS = {
+    "chat_template_kwargs": {"enable_thinking": True, "hello": "world"}
+}
 
 
 class _StubBase:
@@ -25,6 +26,12 @@ class _StubVllmEntity(VllmMixin, _StubBase):
 
 class TestVllmExtraBodyArgs:
     """Tests for _get_extra_body_args instance method."""
+
+    def test_super_call_retained(self) -> None:
+        """Test that data from the super call is retained in the result."""
+        result = _StubVllmEntity()._get_extra_body_args({})
+        assert result["chat_template_kwargs"]["hello"] == "world"
+        assert result["chat_template_kwargs"]["enable_thinking"] is True
 
     @pytest.mark.parametrize(
         "options,extra_expected",


### PR DESCRIPTION
llamacpp and deepseek were not calling `super()._get_extra_body_args` to collect chat template kwargs