### PR TITLE
Sort tool schemas by name for stable prompt prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ I would like to thank the following people for their contributions.
 <tr>
   <td align="center"><a href="https://github.com/Thibaultjaigu"><img src="https://avatars.githubusercontent.com/u/84420566?v=4" width="64" height="64" style="border-radius:50%"></a><br><sub><b><a href="https://github.com/Thibaultjaigu">Thibaultjaigu</a></b></sub></td>
   <td align="center"><a href="https://github.com/Thyraz"><img src="https://avatars.githubusercontent.com/u/170099?v=4" width="64" height="64" style="border-radius:50%"></a><br><sub><b><a href="https://github.com/Thyraz">Thyraz</a></b></sub></td>
+  <td align="center"><a href="https://github.com/jgancedo"><img src="https://avatars.githubusercontent.com/u/17992965?v=4" width="64" height="64" style="border-radius:50%"></a><br><sub><b><a href="https://github.com/jgancedo">jgancedo</a></b></sub></td>
 </tr>
 </table>
 

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -691,9 +691,13 @@ class LocalAiEntity(Entity):
 
         tools: list[ChatCompletionFunctionToolParam] | None = None
         if chat_log.llm_api:
+            # Sorted by name because intent.async_get() yields tools in registration
+            # order, which differs from one restart to the next. Tool schemas render
+            # at the start of the prompt, so a reorder invalidates the whole prefix
+            # of a server-side prompt cache.
             tools = [
                 _format_tool(tool, chat_log.llm_api.custom_serializer)
-                for tool in chat_log.llm_api.tools
+                for tool in sorted(chat_log.llm_api.tools, key=lambda tool: tool.name)
             ]
 
         messages = self._trim_history(

--- a/tests/entities/test_tool_ordering.py
+++ b/tests/entities/test_tool_ordering.py
@@ -1,0 +1,102 @@
+"""Tests that tool schemas are sent in a stable order.
+
+Home Assistant builds the tool list from intent.async_get(), whose order is the order
+integrations registered their intents during startup -- a race that re-rolls on every
+restart. Chat templates render tool schemas at the start of the prompt, so an unstable
+order invalidates the whole prefix of a server-side prompt cache.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import voluptuous as vol
+from homeassistant.const import CONF_MODEL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+
+from custom_components.local_openai.conversation import LocalAiConversationEntity
+
+
+class MockSubentry:
+    """Mock ConfigSubentry that allows updating data."""
+
+    def __setattr__(self, name: str, value: object) -> None:
+        object.__setattr__(self, name, value)
+
+    def __init__(self, data: dict) -> None:
+        self.subentry_id = "test_conversation_subentry_id"
+        self.subentry_type = "conversation"
+        self.title = "Conversation Agent"
+        self.data = data
+        self.unique_id = None
+
+
+class StubTool(llm.Tool):
+    """Minimal llm.Tool with just enough for _format_tool."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.description = f"{name} description"
+        self.parameters = vol.Schema({})
+
+    async def async_call(self, hass, tool_input, llm_context):  # noqa: ANN001, ANN201
+        """Not exercised by these tests."""
+        return {}
+
+
+@pytest.fixture
+def mock_entity(hass: HomeAssistant) -> LocalAiConversationEntity:
+    """Create a conversation entity with no content injection configured."""
+    entry = MagicMock()
+    entry.data = {}
+    entry.runtime_data = MagicMock()
+
+    entity = LocalAiConversationEntity(entry, MockSubentry({CONF_MODEL: "test-model"}))
+    entity.hass = hass
+    return entity
+
+
+def _chat_log(tool_names: list[str]) -> MagicMock:
+    chat_log = MagicMock()
+    chat_log.llm_api.tools = [StubTool(name) for name in tool_names]
+    chat_log.llm_api.custom_serializer = None
+    chat_log.content = []
+    return chat_log
+
+
+async def _captured_tool_names(entity, chat_log) -> list[str]:
+    entity._run_agent_loop = AsyncMock()  # noqa: SLF001
+
+    await entity._async_handle_chat_log(chat_log)  # noqa: SLF001
+
+    model_args = entity._run_agent_loop.call_args.args[1]  # noqa: SLF001
+    return [tool["function"]["name"] for tool in model_args["tools"]]
+
+
+async def test_tools_are_sorted_by_name(mock_entity) -> None:
+    """Tools are sent alphabetically, not in the order the API happened to yield."""
+    chat_log = _chat_log(
+        ["HassTurnOn", "GetLiveContext", "HassLightSet", "HassBroadcast"]
+    )
+
+    assert await _captured_tool_names(mock_entity, chat_log) == [
+        "GetLiveContext",
+        "HassBroadcast",
+        "HassLightSet",
+        "HassTurnOn",
+    ]
+
+
+async def test_tool_order_is_independent_of_input_order(mock_entity) -> None:
+    """The same set of tools produces the same wire order however it arrives.
+
+    This is the property that matters: it is what lets a server-side prompt cache
+    survive a Home Assistant restart.
+    """
+    names = ["HassTurnOn", "GetLiveContext", "HassLightSet", "HassBroadcast"]
+    first = await _captured_tool_names(mock_entity, _chat_log(names))
+    second = await _captured_tool_names(mock_entity, _chat_log(list(reversed(names))))
+
+    assert first == second


### PR DESCRIPTION
Home Assistant builds chat_log.llm_api.tools from intent.async_get(), which returns tools in whatever order integrations happened to register their intents during startup. That order changes between restarts. Tool schemas render at the very start of the prompt, so when it changes the entire cached prefix is invalidated and the next request is a full re-prefill.

On my llama.cpp server with a ~4800 token Assist prompt and no GPU acceleration, replaying a captured request with two tools swapped went from 0.53s to 25.4s. 

Sorting by name makes the order stable across restarts and across machines. Tool order carries no meaning, so this is a no-op for backends that don't cache prompts but nicely stops caching ones from missing. 

The test asserts the wire order is independent of input order, since that's the property that actually protects the cache.