### PR TITLE
Add `use loaded model` option for llama.cpp

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: "Lint"
 
 on:
   push:
-  pull_request:
 
 jobs:
   ruff:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,7 +5,6 @@ name: Run tests
 
 on:
   push:
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     - cron:  "0 0 * * *"
   push:
-  pull_request:
 
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 **This integration has been forked from Home Assistants OpenRouter integration, with the following changes:**
 
 - Added server URL to the initial server configuration
-- Made the API Key optional during initial server configuration: can be left blank if your local server does not require one
+- Made the API Key optional during initial server configuration: can be left blank if your local server does not require
+  one
 - Uses streamed LLM responses
 - Conversation Agents support TTS streaming
 - Automatically strips `<think>` tags from responses
@@ -45,15 +46,18 @@ Adding Tools for Assist to HACS can be using this button:
 <br>
 
 > [!NOTE]
-> If the button above doesn't work, add `https://github.com/skye-harris/hass_local_openai_llm` as a custom repository of type Integration in HACS.
+> If the button above doesn't work, add `https://github.com/skye-harris/hass_local_openai_llm` as a custom repository of
+type Integration in HACS.
 
 * Click install on the `Local OpenAI LLM` integration.
 * Restart Home Assistant.
 
 <details><summary>Manual Install</summary>
 
-* Copy the `local_openai`  folder from [latest release](https://github.com/skye-harris/hass_local_openai_llm/releases/latest) to the [
-  `custom_components` folder](https://developers.home-assistant.io/docs/creating_integration_file_structure/#where-home-assistant-looks-for-integrations) in your config directory.
+* Copy the `local_openai`  folder
+  from [latest release](https://github.com/skye-harris/hass_local_openai_llm/releases/latest) to the [
+  `custom_components` folder](https://developers.home-assistant.io/docs/creating_integration_file_structure/#where-home-assistant-looks-for-integrations)
+  in your config directory.
 * Restart the Home Assistant.
 
 </details>
@@ -73,15 +77,19 @@ After installation, configure the integration through Home Assistant's UI:
 
 - The Server URL must be a fully qualified URL pointing to an OpenAI-compatible API.
     - This typically ends with `/v1` but may differ depending on your server configuration.
-- A Server Type configuration can be set to expose some additional options for different inference servers and providers, where they have been implemented.
+- A Server Type configuration can be set to expose some additional options for different inference servers and
+  providers, where they have been implemented.
 - Assist requires a fairly lengthy context for tooling and entity definitions.
-    - It is strongly recommended to use _at least_ 10k context size and to limit history length and exposed entities to avoid context overflow issues.
-    - This is not configurable through OpenAI-compatible APIs, and needs to be configured with the inference server directly.
+    - It is strongly recommended to use _at least_ 10k context size and to limit history length and exposed entities to
+      avoid context overflow issues.
+    - This is not configurable through OpenAI-compatible APIs, and needs to be configured with the inference server
+      directly.
 - Tool calling must be enabled in your inference engine, eg:
     - **vLLM**: https://docs.vllm.ai/en/latest/features/tool_calling/
     - **llama.cpp**: https://github.com/ggml-org/llama.cpp/blob/master/docs/function-calling.md
 - Parallel tool calling requires support from both your model and inference server.
-    - In some cases, control of this is handled by the server directly, in which case toggling this will not have any result.
+    - In some cases, control of this is handled by the server directly, in which case toggling this will not have any
+      result.
 - Chat Template Arguments allow you to provide custom arguments to your model
     - Arguments are supplied as key/value pairs and provided to the `chat_template_kwargs` request parameter
     - Values support Jinja2 templates, in order to provide non-string and more complex data structures
@@ -93,13 +101,16 @@ After installation, configure the integration through Home Assistant's UI:
     - Internally managed parameters, and parameters with dedicated configuration options, cannot be configured here
     - Provider support differs; see your provider and model documentation for available parameters
 - AI Task entities can be configured for Text and/or Image generation capabilities
-    - This capability uses the [Images API](https://developers.openai.com/api/reference/resources/images) spec and requires support from your chosen image generation server
+    - This capability uses the [Images API](https://developers.openai.com/api/reference/resources/images) spec and
+      requires support from your chosen image generation server
     - Support has been developed and tested with [StableDiffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)
-- Always continue conversation — When a voice agent finishes speaking, passes the active voice turn back to the user in order to naturally continue the conversation
+- Always continue conversation — When a voice agent finishes speaking, passes the active voice turn back to the user in
+  order to naturally continue the conversation
     - If the user speaks, the assistant continues the conversation naturally
     - If the user stays silent, the assistant stops following up after a timeout
     - If the user says a stop keyword (e.g. "STOP") while the agent is speaking, the follow-up is cancelled immediately
-    - When disabled (default), only assistant responses ending in a question will pass the active voice turn back to the user
+    - When disabled (default), only assistant responses ending in a question will pass the active voice turn back to the
+      user
 
 ---
 
@@ -107,26 +118,30 @@ After installation, configure the integration through Home Assistant's UI:
 
 **Custom HTTP Headers**
 
-Add custom HTTP headers as key-value pairs to all LLM API requests. Useful for passing custom metadata or provider-specific headers.
+Add custom HTTP headers as key-value pairs to all LLM API requests. Useful for passing custom metadata or
+provider-specific headers.
 
 ### DeepSeek Cloud Configuration
 
 #### Reasoning Effort
 
-When the server type is set to *DeepSeek Cloud*, both conversation and AI task agents show a new **DeepSeek Configuration** section with a **Reasoning Effort** option.
-This option controls whether thinking is enabled, and what level of reasoning to perform on the request.
+When the server type is set to *DeepSeek Cloud*, both conversation and AI task agents show a new **DeepSeek
+Configuration** section with a **Reasoning Effort** option. This option controls whether thinking is enabled, and what
+level of reasoning to perform on the request.
 
 - **Disabled** (default) — no thinking tokens.
 - **High** — enables thinking with standard reasoning effort.
 - **Max** — enables thinking with maximum reasoning effort.
 
-When enabled, thinking content returned by the model is also fed back into the conversation as reasoning content on supported Home Assistant versions (2026.4+).
+When enabled, thinking content returned by the model is also fed back into the conversation as reasoning content on
+supported Home Assistant versions (2026.4+).
 
 ---
 
 ### llama.cpp Configuration
 
-When the server type is set to *llama.cpp*, both conversation and AI task agents show a **llama.cpp Configuration** section with the following options.
+When the server type is set to *llama.cpp*, both conversation and AI task agents show a **llama.cpp Configuration**
+section with the following options.
 
 #### Enable thinking
 
@@ -141,24 +156,35 @@ _Note: This option completely overrides any existing `enable_thinking` option in
 
 Controls whether thinking/reasoning content from prior conversation turns is sent back in new completion requests.
 
-Some reasoning models require this enabled, and others require it disabled. Check the documentation for your model if unsure. 
+Some reasoning models require this enabled, and others require it disabled. Check the documentation for your model if
+unsure.
 
-- **Enabled** (default) — prior-turn `thinking_content` is passed as `reasoning_content` in the next request, allowing the model to see its own prior reasoning.
-- **Disabled** — prior thinking context is stripped before sending. Use for models that reject prior reasoning context (e.g., Gemma 4).
+- **Enabled** (default) — prior-turn `thinking_content` is passed as `reasoning_content` in the next request, allowing
+  the model to see its own prior reasoning.
+- **Disabled** — prior thinking context is stripped before sending. Use for models that reject prior reasoning context
+  (e.g., Gemma 4).
 
 #### Slot ID
 
 Pins requests to a specific llama.cpp server slot for prompt-cache reuse. Leave empty to allow any slot to be used.
 
-#### Model naming
+#### Use loaded model
 
-llama.cpp exposes the value supplied via its `--alias` flag on the model object. When an alias is set it is used as the model's display name; otherwise the raw model `id` (typically the full model file path) is used, with the path and `.gguf`
-extension stripped for a cleaner name.
+When enabled, the integration prioritizes using models already resident in memory to minimize latency.
+
+It follows these rules:
+
+- **Primary:** Uses the configured model if it is currently loaded.
+- **Fallback:** If the configured model is not loaded, it selects the first loaded model that supports the required modality (e.g., image inputs). If no compatible loaded models exist, it defaults back to the configured model.
+
+This is ideal for users with diverse model setups who want to route tasks to whatever is currently available in memory rather than waiting for a specific model to load.
 
 #### Sampling Parameters
 
 These options control how llama.cpp selects tokens during text generation.<br>
-Please refer to the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/tools/completion/README.md#generation-flags) for further information and usage.
+Please refer to
+the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/tools/completion/README.md#generation-flags)
+for further information and usage.
 
 | Parameter            | Description                                                                                                | Range  |
 |----------------------|------------------------------------------------------------------------------------------------------------|--------|
@@ -168,35 +194,48 @@ Please refer to the [llama.cpp documentation](https://github.com/ggml-org/llama.
 | **Repeat Penalty**   | Penalizes repeat sequences of tokens.                                                                      | -2–2   |
 | **Presence Penalty** | Penalizes tokens already present in the context.                                                           | -2–2   |
 
+#### Model naming
+
+llama.cpp exposes the value supplied via its `--alias` flag on the model object. When an alias is set it is used as the
+model's display name; otherwise the raw model `id` (typically the full model file path) is used, with the path and
+`.gguf`
+extension stripped for a cleaner name.
+
 ---
 
 ### LocalAI Configuration
 
-When the server type is set to *LocalAI*, Chat Template Arguments are sent via the
-OpenAI `metadata` request field rather than a top-level `chat_template_kwargs` field,
-as this is where LocalAI reads chat template variables from. Values are coerced to
-strings, per LocalAI's metadata convention.
+When the server type is set to *LocalAI*, Chat Template Arguments are sent via the OpenAI `metadata` request field
+rather than a top-level `chat_template_kwargs` field, as this is where LocalAI reads chat template variables from.
+Values are coerced to strings, per LocalAI's metadata convention.
 
 See [LocalAI model configuration](https://localai.io/advanced/model-configuration/index.html#custom-chat_template_kwargs).
 ---
 
 ### vLLM Configuration
 
-When the server type is set to *vLLM*, both conversation and AI task agents show a **vLLM Configuration** section with the following options.
+When the server type is set to *vLLM*, both conversation and AI task agents show a **vLLM Configuration** section with
+the following options.
 
 #### Thinking token budget
 
-Caps how many tokens the model may spend on reasoning, via the `thinking_token_budget` request parameter. Once the budget is reached, vLLM forces the reasoning block to be closed and the model proceeds to its answer.
+Caps how many tokens the model may spend on reasoning, via the `thinking_token_budget` request parameter. Once the
+budget is reached, vLLM forces the reasoning block to be closed and the model proceeds to its answer.
 
 - **Empty** (default) — no budget is sent, and the server default applies.
 - **0** — the reasoning block is closed immediately, so the model answers without thinking.
 - **Any higher value** — limits reasoning to that number of tokens.
 
-_Note: This only limits the length of thinking, it does not enable or disable it. Whether the model thinks at all is controlled by the model's chat template, typically via an `enable_thinking` Chat Template Argument._
+_Note: This only limits the length of thinking, it does not enable or disable it. Whether the model thinks at all is
+controlled by the model's chat template, typically via an `enable_thinking` Chat Template Argument._
 
-Requires a reasoning model and a vLLM version that supports the parameter. Refer to the [vLLM reasoning outputs documentation](https://docs.vllm.ai/en/latest/features/reasoning_outputs/) for further information.
+Requires a reasoning model and a vLLM version that supports the parameter. Refer to
+the [vLLM reasoning outputs documentation](https://docs.vllm.ai/en/latest/features/reasoning_outputs/) for further
+information.
 
-When the budget is reached the reasoning block is closed with the parser's end string, which can leave the model cut off mid-thought. A wrap-up message can be added there to transition into the answer more gracefully, though this is configured on the vLLM server rather than per request:
+When the budget is reached the reasoning block is closed with the parser's end string, which can leave the model cut off
+mid-thought. A wrap-up message can be added there to transition into the answer more gracefully, though this is
+configured on the vLLM server rather than per request:
 
 ```
 --reasoning-parser qwen3
@@ -207,12 +246,14 @@ When the budget is reached the reasoning block is closed with the parser's end s
 
 ### Experimental: Date/Time Context Injection Role
 
-This integration supports injecting some dynamic content, presently the date and time, into the active Conversation Agent prompt when making a request.
-This was added as it is beneficial for the model to be grounded with this context in its role as an assistant, and was previously added to the system prompt by Home Assistant itself before later being removed due to negative effects on prompt caching
-and performance.
+This integration supports injecting some dynamic content, presently the date and time, into the active Conversation
+Agent prompt when making a request. This was added as it is beneficial for the model to be grounded with this context in
+its role as an assistant, and was previously added to the system prompt by Home Assistant itself before later being
+removed due to negative effects on prompt caching and performance.
 
-This was previously always-on but has been extracted as an **experimental** configuration option as this is not a once-size-fits-all for all models.
-To this end I have provided a number of options so that users can try them out and select the one that works best, or disable entirely if none work well, for their chosen model.
+This was previously always-on but has been extracted as an **experimental** configuration option as this is not a
+once-size-fits-all for all models. To this end I have provided a number of options so that users can try them out and
+select the one that works best, or disable entirely if none work well, for their chosen model.
 
 The available options are:
 
@@ -220,7 +261,8 @@ The available options are:
 
 The date and time are inserted as a `Tool Call Result` message to the model, before the current user message.
 
-As long as the model does not reject it, this is the recommended method to use and produces the most reliable results during testing.
+As long as the model does not reject it, this is the recommended method to use and produces the most reliable results
+during testing.
 
 #### <u>Assistant</u>:
 
@@ -232,21 +274,25 @@ In cases where the `Tool Call Result` role method does not work for a model, thi
 
 The date and time are inserted as an additional `User` message to the model, before the current user message.
 
-Recommended only where neither the `System` nor `Assistant` injection methods work for the model, but may not produce desirable results.
-Some models have been known to repeat the date/time back to the user without request.
+Recommended only where neither the `System` nor `Assistant` injection methods work for the model, but may not produce
+desirable results. Some models have been known to repeat the date/time back to the user without request.
 
 #### <u>Disabled (no selection)</u>:
 
-If your model simply refuses to work well with any method, simply remove the value from the configuration option to disable this again.
+If your model simply refuses to work well with any method, simply remove the value from the configuration option to
+disable this again.
 
 ## Experimental: Retrieval Augmented Generation (RAG) with Weaviate
 
-Retrieval Augmented Generation is used to pre-feed your LLM messages with related data to provide contextually relevant information to the model based on the user input message.
+Retrieval Augmented Generation is used to pre-feed your LLM messages with related data to provide contextually relevant
+information to the model based on the user input message.
 
-This integration supports connecting your Agent to a Weaviate vector database server.
-Once configured, user messages to the Agent will be queried against the Weaviate database first, and the result data pre-emptively injected into the current conversation as contextual data for the Agent to utilise in their response.
+This integration supports connecting your Agent to a Weaviate vector database server. Once configured, user messages to
+the Agent will be queried against the Weaviate database first, and the result data pre-emptively injected into the
+current conversation as contextual data for the Agent to utilise in their response.
 
-This is not a general-purpose "memory" for the Agent: content is only provided to the Agent if it matches on the current user input message to the model.
+This is not a general-purpose "memory" for the Agent: content is only provided to the Agent if it matches on the current
+user input message to the model.
 
 See the [Weaviate documentation](https://docs.weaviate.io/weaviate) for further information on Weaviate.
 
@@ -256,22 +302,28 @@ See the [Weaviate documentation](https://docs.weaviate.io/weaviate) for further 
 
 1. **Install Weaviate [locally](https://docs.weaviate.io/weaviate/quickstart/local)**
     1. A pre-made `docker-compose.yml` is provided in the `weaviate` directory of this repository.
-    2. _Weaviate Cloud is not supported: there is no free tier available and its cheapest pricing plan isn't attractive for personal/home use, and so I don't anticipate demand for this._
+    2. _Weaviate Cloud is not supported: there is no free tier available and its cheapest pricing plan isn't attractive
+       for personal/home use, and so I don't anticipate demand for this._
 2. **Reconfigure your LLM Server entity (**not** the Agent entity) in Home Assistant.**
-    1. Expand the `Weaviate configuration` section and fill in the details server address and API key (`homeassistant` if using the supplied `docker-compose.yml`).
+    1. Expand the `Weaviate configuration` section and fill in the details server address and API key (`homeassistant`
+       if using the supplied `docker-compose.yml`).
 3. **Optional: Reconfigure your AI Agent entities in Home Assistant.**
     1. This is only needed if you wish to change the default Weaviate values on a per-agent basis:
-        1. Object class name: Defaults to `Homeassistant`, can be changed if you want a different data store for the Agent. The integration will handle creating the required object class within Weaviate if it does not already exist.
+        1. Object class name: Defaults to `Homeassistant`, can be changed if you want a different data store for the
+           Agent. The integration will handle creating the required object class within Weaviate if it does not already
+           exist.
         2. Maximum number of results to use: Defaults to `2`.
         3. Result score threshold: Defaults to `0.9`.
-        4. Hybrid search alpha: Defaults to `0.5`. Balances the hybrid result scoring between 0 (fully text-matched) and 1 (fully vectorised) matching.
+        4. Hybrid search alpha: Defaults to `0.5`. Balances the hybrid result scoring between 0 (fully text-matched) and
+           1 (fully vectorised) matching.
 
 ### Managing Data
 
 Self-hosted Weaviate does not come with a front-end to manage data at all at this current point in time.
 
-I have included a simple NodeJS-based WebApp server within the `/weaviate` directory of this repository, that can be used to connect to your local Weaviate instance and view, query, and manage the data in your object class.
-This is also setup into the supplied `docker-compose.yml` and exposed on port 9090 by default.
+I have included a simple NodeJS-based WebApp server within the `/weaviate` directory of this repository, that can be
+used to connect to your local Weaviate instance and view, query, and manage the data in your object class. This is also
+setup into the supplied `docker-compose.yml` and exposed on port 9090 by default.
 
 This tool supports the following basic functionality:
 
@@ -280,16 +332,19 @@ This tool supports the following basic functionality:
 - Add new entry data to a class.
 - Perform vector and hybrid searches against an object class.
 
-_This is not a general-purpose Weaviate management tool, rather it is purpose-built specifically for use with this integration and the object classes that it creates._
+_This is not a general-purpose Weaviate management tool, rather it is purpose-built specifically for use with this
+integration and the object classes that it creates._
 
 ### Notes
 
 - Only the current generations user message is queried in the database, no prior user messages are included.
-- Search results are used for the **current** user/assistant turns only (including multiturn tool usages), and do not carry forward to subsequent user/assistant turns.
+- Search results are used for the **current** user/assistant turns only (including multiturn tool usages), and do not
+  carry forward to subsequent user/assistant turns.
 - Objects are stored as 2 pieces of data: the `query`, and the `content`:
     - The `query` is what is vectorised and the user inputs searched against.
     - The `content` is the main content to be provided to be fed to the LLM, along with its `query` text for context.
-- Useful for providing contextual information to the LLM for different types of requests, without having all of it in your prompt at all times.
+- Useful for providing contextual information to the LLM for different types of requests, without having all of it in
+  your prompt at all times.
 - I have performed basic testing of this with a variety of models across a few inference providers:
     - Qwen 3-VL 8B locally on llama.cpp.
     - Minimax m2.1 on OpenRouter.
@@ -298,13 +353,15 @@ _This is not a general-purpose Weaviate management tool, rather it is purpose-bu
     - Gemma 3 27B on Scaleway.
     - Llama 3.1 8B on Scaleway.
     - GPT-OSS-120B on Scaleway.
-- A service action, `local_openai.add_to_weaviate`, can be used from within Home Assistant to add content to the database.
+- A service action, `local_openai.add_to_weaviate`, can be used from within Home Assistant to add content to the
+  database.
 
 ---
 
 ## Web Search & Additional Tools
 
-Looking to add some more functionality to your Home Assistant conversation agent, such as web and localised business/location search? Check out my [Tools for Assist](https://github.com/skye-harris/llm_intents) integration here!
+Looking to add some more functionality to your Home Assistant conversation agent, such as web and localised
+business/location search? Check out my [Tools for Assist](https://github.com/skye-harris/llm_intents) integration here!
 
 These tools exist as a separate integration for compatibility across the wider Home Assistant Conversation ecosystem.
 
@@ -312,7 +369,9 @@ These tools exist as a separate integration for compatibility across the wider H
 
 ## Acknowledgements
 
-This integration was forked from the [OpenRouter](https://github.com/home-assistant/core/tree/dev/homeassistant/components/open_router) integration for Home Assistant by [@joostlek](https://github.com/joostlek).
+This integration was forked from
+the [OpenRouter](https://github.com/home-assistant/core/tree/dev/homeassistant/components/open_router) integration for
+Home Assistant by [@joostlek](https://github.com/joostlek).
 
 ## Contributors
 
@@ -347,6 +406,7 @@ I would like to thank the following people for their contributions.
 
 ## Support Development
 
-If you find this integration useful and would like to support development, please consider [buying me a coffee](https://www.buymeacoffee.com/skyeharris).
+If you find this integration useful and would like to support development, please
+consider [buying me a coffee](https://www.buymeacoffee.com/skyeharris).
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/skyeharris)

--- a/custom_components/local_openai/ai_task.py
+++ b/custom_components/local_openai/ai_task.py
@@ -214,7 +214,7 @@ class LocalAITaskEntity(
             mime_type=mime_type,
             width=width,
             height=height,
-            model=self.model,
+            model=await self._async_get_model(),
         )
 
     async def _async_handle_image_response(
@@ -246,13 +246,13 @@ class LocalAITaskEntity(
                 response = await client.images.edit(
                     image=image_arg,
                     prompt=ai_task.instructions,
-                    model=self.model,
+                    model=await self._async_get_model(),
                     response_format="b64_json",
                 )
             else:
                 response = await client.images.generate(
                     prompt=ai_task.instructions,
-                    model=self.model,
+                    model=await self._async_get_model(),
                     response_format="b64_json",
                 )
         except openai.OpenAIError as err:

--- a/custom_components/local_openai/const.py
+++ b/custom_components/local_openai/const.py
@@ -35,6 +35,7 @@ CONF_LLAMACPP_TOP_K = "llamacpp_top_k"
 CONF_LLAMACPP_MIN_P = "llamacpp_min_p"
 CONF_LLAMACPP_REPEAT_PENALTY = "llamacpp_repeat_penalty"
 CONF_LLAMACPP_PRESENCE_PENALTY = "llamacpp_presence_penalty"
+CONF_LLAMACPP_USE_LOADED_MODEL = "llamacpp_use_loaded_model"
 CONF_VLLM_CONFIG = "vllm_config"
 CONF_VLLM_THINKING_TOKEN_BUDGET = "vllm_thinking_token_budget"  # noqa: S105
 CONF_DEEPSEEK_CONFIG = "deepseek_config"

--- a/custom_components/local_openai/entities/llama_cpp.py
+++ b/custom_components/local_openai/entities/llama_cpp.py
@@ -24,13 +24,17 @@ from custom_components.local_openai.const import (
     CONF_LLAMACPP_REPEAT_PENALTY,
     CONF_LLAMACPP_TOP_K,
     CONF_LLAMACPP_TOP_P,
+    CONF_LLAMACPP_USE_LOADED_MODEL,
 )
 from custom_components.local_openai.conversation import LocalAiConversationEntity
 
 if TYPE_CHECKING:
     from types import MappingProxyType
 
+    from homeassistant.config_entries import ConfigSubentry
     from openai.types.chat import ChatCompletionMessageParam
+
+    from . import LocalAiConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +67,7 @@ def _get_llama_cpp_schema() -> dict:
     return {
         vol.Required(CONF_LLAMACPP_ENABLE_THINKING, default=False): bool,
         vol.Required(CONF_LLAMACPP_INCLUDE_PRIOR_THINKING, default=True): bool,
+        vol.Required(CONF_LLAMACPP_USE_LOADED_MODEL, default=False): bool,
         vol.Optional(CONF_LLAMACPP_ID_SLOT): NumberSelector(
             NumberSelectorConfig(min=0, step=1, mode=NumberSelectorMode.BOX),
         ),
@@ -131,6 +136,85 @@ def get_ai_task_config_schema() -> dict:
 
 class LlamaCppMixin:
     """Mixin for llama.cpp entities with shared logic."""
+
+    def __init__(
+        self,
+        entry: LocalAiConfigEntry,
+        subentry: ConfigSubentry,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(entry, subentry)
+
+    async def _async_get_model(
+        self,
+        chat_log: conversation.ChatLog | None = None,
+    ) -> str:
+        """
+        Return the model to use.
+
+        When use_loaded_model is enabled, fetches fresh from the server's
+        /v1/models endpoint every time. Prefers the configured model if it
+        is loaded; falls back to the first loaded model; falls back to the
+        configured model on any error.
+
+        Modalities are detected from chat_log.content — if any content item
+        has an image attachment, ["image"] is used to filter loaded models.
+        Only models whose architecture.input_modalities contains all required
+        modalities are considered.
+        """
+        opts = self.subentry.data.get(CONF_LLAMACPP_CONFIG, {})
+        if not opts.get(CONF_LLAMACPP_USE_LOADED_MODEL, False):
+            return self.model
+
+        try:
+            client = self.entry.runtime_data
+            response = await client.models.list()
+
+            loaded_models = [
+                model
+                for model in response.data
+                if model.status.get("value") == "loaded"
+            ]
+
+            if not loaded_models:
+                return self.model
+
+            if chat_log is not None:
+                modalities = [
+                    "image"
+                    for content in chat_log.content
+                    if hasattr(content, "attachments")
+                    and content.attachments
+                    and any(
+                        attachment.mime_type.startswith("image/")
+                        for attachment in content.attachments
+                    )
+                ]
+
+                if modalities:
+                    loaded_models = [
+                        model
+                        for model in loaded_models
+                        if set(modalities).issubset(
+                            set(
+                                getattr(model, "architecture", {}).get(
+                                    "input_modalities", []
+                                )
+                            )
+                        )
+                    ]
+
+                    if not loaded_models:
+                        return self.model
+
+            for model in loaded_models:
+                if model.id == self.model:
+                    return model.id
+
+            return loaded_models[0].id
+        except Exception:
+            _LOGGER.exception("Failed to resolve loaded model, using configured model")
+            return self.model
 
     def _get_extra_body_args(
         self,

--- a/custom_components/local_openai/entities/llama_cpp.py
+++ b/custom_components/local_openai/entities/llama_cpp.py
@@ -179,6 +179,10 @@ class LlamaCppMixin:
             if not loaded_models:
                 return self.model
 
+            for model in loaded_models:
+                if model.id == self.model:
+                    return model.id
+
             if chat_log is not None:
                 modalities = [
                     "image"
@@ -206,10 +210,6 @@ class LlamaCppMixin:
 
                     if not loaded_models:
                         return self.model
-
-            for model in loaded_models:
-                if model.id == self.model:
-                    return model.id
 
             return loaded_models[0].id
         except Exception:

--- a/custom_components/local_openai/entity.py
+++ b/custom_components/local_openai/entity.py
@@ -31,7 +31,11 @@ from openai.types.chat import (
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import Function
 from openai.types.shared_params import FunctionDefinition, ResponseFormatJSONSchema
-from probatio import to_openapi as convert
+
+try:
+    from probatio import to_openapi as convert
+except ImportError:
+    from voluptuous_openapi import convert
 
 from .const import (
     CONF_CHAT_TEMPLATE_KWARGS,
@@ -193,6 +197,12 @@ class LocalAiEntity(Entity):
             name=subentry.title,
             entry_type=dr.DeviceEntryType.SERVICE,
         )
+
+    async def _async_get_model(
+        self, chat_log: conversation.ChatLog | None = None
+    ) -> str:
+        """Return the model to use."""
+        return self.model
 
     @property
     def options(self) -> dict:
@@ -686,8 +696,9 @@ class LocalAiEntity(Entity):
         # Pass conversation session ID via metadata for LLM proxy tracing (LiteLLM + Langfuse)
         pass_session_id = server_options.get(CONF_PASS_SESSION_ID, False)
         max_message_history = int(options.get(CONF_MAX_MESSAGE_HISTORY, 0))
+
         model_args = {
-            "model": self.model,
+            "model": await self._async_get_model(chat_log),
             "parallel_tool_calls": parallel_tool_calls,
             "extra_headers": {
                 "HTTP-Referer": "https://github.com/skye-harris/hass_local_openai_llm",

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -160,7 +160,8 @@
                 "llamacpp_top_k": "Top-k",
                 "llamacpp_min_p": "Min-p",
                 "llamacpp_repeat_penalty": "Repeat penalty",
-                "llamacpp_presence_penalty": "Presence penalty"
+                "llamacpp_presence_penalty": "Presence penalty",
+                "llamacpp_use_loaded_model": "Use currently loaded model"
               },
               "data_description": {
                 "llamacpp_enable_thinking": "Pass enable_thinking=true via chat_template_kwargs to enable reasoning on supported models",
@@ -170,7 +171,8 @@
                 "llamacpp_top_k": "Number of highest probability tokens to sample from. (1-1000)",
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
-                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)",
+                "llamacpp_use_loaded_model": "Fetch the active model from the server at request time. Requires the model to be pre-loaded on the llama.cpp server."
               }
             },
             "vllm_config": {
@@ -251,7 +253,8 @@
                 "llamacpp_top_k": "Top-k",
                 "llamacpp_min_p": "Min-p",
                 "llamacpp_repeat_penalty": "Repeat penalty",
-                "llamacpp_presence_penalty": "Presence penalty"
+                "llamacpp_presence_penalty": "Presence penalty",
+                "llamacpp_use_loaded_model": "Use currently loaded model"
               },
               "data_description": {
                 "llamacpp_enable_thinking": "Pass enable_thinking=true via chat_template_kwargs to enable reasoning on supported models",
@@ -261,7 +264,8 @@
                 "llamacpp_top_k": "Number of highest probability tokens to sample from. (1-1000)",
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
-                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)",
+                "llamacpp_use_loaded_model": "Fetch the active model from the server at request time. Requires the model to be pre-loaded on the llama.cpp server."
               }
             },
             "vllm_config": {
@@ -295,8 +299,8 @@
       "entry_type": "Conversation agent",
       "error": {
         "cannot_connect_weaviate": "Could not communicate with the Weaviate server",
-        "request_body_parameter_already_configurable": "The request body parameter \"{key}\" already has a dedicated configuration option.",
-        "reserved_request_body_parameter": "The request body parameter \"{key}\" is reserved and cannot be configured here."
+        "request_body_parameter_already_configurable": "The request body parameter '{key}' already has a dedicated configuration option.",
+        "reserved_request_body_parameter": "The request body parameter '{key}' is reserved and cannot be configured here."
       },
       "abort": {
         "cannot_connect": "Could not communicate with the LLM server",
@@ -358,7 +362,8 @@
                 "llamacpp_top_k": "Top-k",
                 "llamacpp_min_p": "Min-p",
                 "llamacpp_repeat_penalty": "Repeat penalty",
-                "llamacpp_presence_penalty": "Presence penalty"
+                "llamacpp_presence_penalty": "Presence penalty",
+                "llamacpp_use_loaded_model": "Use currently loaded model"
               },
               "data_description": {
                 "llamacpp_enable_thinking": "Pass enable_thinking=true via chat_template_kwargs to enable reasoning on supported models",
@@ -368,7 +373,8 @@
                 "llamacpp_top_k": "Number of highest probability tokens to sample from. (1-1000)",
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
-                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)",
+                "llamacpp_use_loaded_model": "Fetch the active model from the server at request time. Requires the model to be pre-loaded on the llama.cpp server."
               }
             },
             "vllm_config": {
@@ -435,7 +441,8 @@
                 "llamacpp_top_k": "Top-k",
                 "llamacpp_min_p": "Min-p",
                 "llamacpp_repeat_penalty": "Repeat penalty",
-                "llamacpp_presence_penalty": "Presence penalty"
+                "llamacpp_presence_penalty": "Presence penalty",
+                "llamacpp_use_loaded_model": "Use currently loaded model"
               },
               "data_description": {
                 "llamacpp_enable_thinking": "Pass enable_thinking=true via chat_template_kwargs to enable reasoning on supported models",
@@ -445,7 +452,8 @@
                 "llamacpp_top_k": "Number of highest probability tokens to sample from. (1-1000)",
                 "llamacpp_min_p": "Combined with top-p for more controlled sampling. (0-1)",
                 "llamacpp_repeat_penalty": "Positive values discourage repetition. (-2 to 2)",
-                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)"
+                "llamacpp_presence_penalty": "Positive values discourage repetition of new tokens. (-2 to 2)",
+                "llamacpp_use_loaded_model": "Fetch the active model from the server at request time. Requires the model to be pre-loaded on the llama.cpp server."
               }
             },
             "vllm_config": {
@@ -465,8 +473,8 @@
       },
       "entry_type": "AI task",
       "error": {
-        "request_body_parameter_already_configurable": "The request body parameter \"{key}\" already has a dedicated configuration option.",
-        "reserved_request_body_parameter": "The request body parameter \"{key}\" is reserved and cannot be configured here."
+        "request_body_parameter_already_configurable": "The request body parameter '{key}' already has a dedicated configuration option.",
+        "reserved_request_body_parameter": "The request body parameter '{key}' is reserved and cannot be configured here."
       },
       "abort": {
         "cannot_connect": "Could not communicate with the server",

--- a/custom_components/local_openai/translations/en.json
+++ b/custom_components/local_openai/translations/en.json
@@ -299,8 +299,8 @@
       "entry_type": "Conversation agent",
       "error": {
         "cannot_connect_weaviate": "Could not communicate with the Weaviate server",
-        "request_body_parameter_already_configurable": "The request body parameter '{key}' already has a dedicated configuration option.",
-        "reserved_request_body_parameter": "The request body parameter '{key}' is reserved and cannot be configured here."
+        "request_body_parameter_already_configurable": "The request body parameter {key} already has a dedicated configuration option.",
+        "reserved_request_body_parameter": "The request body parameter {key} is reserved and cannot be configured here."
       },
       "abort": {
         "cannot_connect": "Could not communicate with the LLM server",
@@ -473,8 +473,8 @@
       },
       "entry_type": "AI task",
       "error": {
-        "request_body_parameter_already_configurable": "The request body parameter '{key}' already has a dedicated configuration option.",
-        "reserved_request_body_parameter": "The request body parameter '{key}' is reserved and cannot be configured here."
+        "request_body_parameter_already_configurable": "The request body parameter {key} already has a dedicated configuration option.",
+        "reserved_request_body_parameter": "The request body parameter {key} is reserved and cannot be configured here."
       },
       "abort": {
         "cannot_connect": "Could not communicate with the server",

--- a/tests/entities/llama_cpp/test_llama_cpp_model_args.py
+++ b/tests/entities/llama_cpp/test_llama_cpp_model_args.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from custom_components.local_openai.const import (
     CONF_LLAMACPP_CONFIG,
     CONF_LLAMACPP_ENABLE_THINKING,
@@ -37,7 +36,8 @@ class _StubBase:
 
 
 class _StubLlamaCppEntity(LlamaCppMixin, _StubBase):
-    pass
+    def __init__(self, entry=None, subentry=None) -> None:
+        pass
 
 
 class TestLlamaCppExtraBodyArgs:

--- a/tests/entities/llama_cpp/test_schema.py
+++ b/tests/entities/llama_cpp/test_schema.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
 import pytest
-
+import voluptuous as vol
 from custom_components.local_openai.const import (
     CONF_LLAMACPP_ENABLE_THINKING,
     CONF_LLAMACPP_ID_SLOT,
@@ -14,6 +13,7 @@ from custom_components.local_openai.const import (
     CONF_LLAMACPP_REPEAT_PENALTY,
     CONF_LLAMACPP_TOP_K,
     CONF_LLAMACPP_TOP_P,
+    CONF_LLAMACPP_USE_LOADED_MODEL,
 )
 from custom_components.local_openai.entities.llama_cpp import (
     _get_llama_cpp_schema,
@@ -55,7 +55,8 @@ class TestValidation:
             CONF_LLAMACPP_REPEAT_PENALTY: 1.0,
             CONF_LLAMACPP_PRESENCE_PENALTY: 0.0,
         }
-        assert validator(data) == data
+        expected = {**data, CONF_LLAMACPP_USE_LOADED_MODEL: False}
+        assert validator(data) == expected
 
     def test_default_enable_thinking(self):
         validator = _validator()
@@ -73,7 +74,7 @@ class TestValidation:
         )
         assert result[CONF_LLAMACPP_ENABLE_THINKING] is True
         assert result[CONF_LLAMACPP_INCLUDE_PRIOR_THINKING] is False
-        assert len(result) == 2
+        assert len(result) == 3
 
     def test_rejects_non_bool_enable_thinking(self):
         validator = _validator()

--- a/tests/entities/llama_cpp/test_use_loaded_model.py
+++ b/tests/entities/llama_cpp/test_use_loaded_model.py
@@ -344,8 +344,8 @@ class TestLlamaCppUseLoadedModel:
         chat_log = _make_chat_log([["image/png"]])
         assert await entity._async_get_model(chat_log) == "my-configured-model"
 
-    async def test_modalities_mismatch_uses_first_matching_loaded(self) -> None:
-        """When config model doesn't match image modality, first matching loaded model is used."""
+    async def test_modalities_mismatch_uses_configured_model(self) -> None:
+        """Configured model takes priority even if its modalities don't match the chat content."""
         mock_config_model = MagicMock()
         mock_config_model.id = "text-only-model"
         mock_config_model.status.get.return_value = "loaded"
@@ -376,7 +376,7 @@ class TestLlamaCppUseLoadedModel:
 
         entity = TestEntity(entry, subentry)
         chat_log = _make_chat_log([["image/png"]])
-        assert await entity._async_get_model(chat_log) == "multimodal-model"
+        assert await entity._async_get_model(chat_log) == "text-only-model"
 
     async def test_modalities_no_match_falls_back_to_configured(self) -> None:
         """When no loaded model matches image modality, fall back to configured model."""

--- a/tests/entities/llama_cpp/test_use_loaded_model.py
+++ b/tests/entities/llama_cpp/test_use_loaded_model.py
@@ -1,0 +1,437 @@
+"""Tests for the llama.cpp use_loaded_model feature."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.local_openai.const import (
+    CONF_LLAMACPP_CONFIG,
+    CONF_LLAMACPP_USE_LOADED_MODEL,
+)
+from custom_components.local_openai.entities.llama_cpp import LlamaCppMixin
+
+
+def _make_chat_log(
+    attachments: list[list[str]] | None = None,
+) -> MagicMock:
+    """Create a mock ChatLog with content items that have optional image attachments.
+
+    Args:
+        attachments: List of attachment mime_types per content item.
+                     None = no attachments on that content item.
+                     Empty list = content item exists but has no attachments.
+    """
+    content_items = []
+    if attachments is None:
+        attachments = [None]
+
+    for mime_types in attachments:
+        item = MagicMock()
+        if mime_types is None:
+            item.attachments = None
+        elif len(mime_types) == 0:
+            item.attachments = []
+        else:
+            item.attachments = [MagicMock(mime_type=mt) for mt in mime_types]
+        content_items.append(item)
+
+    chat_log = MagicMock()
+    chat_log.content = content_items
+    return chat_log
+
+
+class _StubSubentry:
+    """Stub subentry for testing."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+
+class _StubEntry:
+    """Stub config entry for testing."""
+
+    def __init__(self, runtime_data: MagicMock) -> None:
+        self.runtime_data = runtime_data
+
+
+class _StubBaseEntity:
+    """Stub base entity that mimics LocalAiEntity initialization."""
+
+    def __init__(self, entry: MagicMock, subentry: MagicMock) -> None:
+        self.entry = entry
+        self.subentry = subentry
+        # Mimic what LocalAiEntity.__init__ does
+        self.model = subentry.data.get("model", subentry.data.get("CONF_MODEL"))
+
+
+class TestLlamaCppUseLoadedModel:
+    """Tests for the use_loaded_model async method in LlamaCppMixin."""
+
+    async def test_disabled_uses_configured_model(self) -> None:
+        """When use_loaded_model is False, return the configured model."""
+        entry = MagicMock()
+        subentry = _StubSubentry(
+            {
+                "model": "my-configured-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: False,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "my-configured-model"
+
+    async def test_enabled_queries_models_endpoint(self) -> None:
+        """When use_loaded_model is True, query /models and return loaded model."""
+        mock_loaded_model = MagicMock()
+        mock_loaded_model.id = "qwen3.6-35b-a3b"
+        mock_loaded_model.status.get.return_value = "loaded"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_loaded_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "some-other-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "qwen3.6-35b-a3b"
+
+    async def test_prefers_config_model_if_loaded(self) -> None:
+        """When config model is among loaded models, use config model."""
+        mock_loaded_1 = MagicMock()
+        mock_loaded_1.id = "other-model"
+        mock_loaded_1.status.get.return_value = "loaded"
+
+        mock_loaded_2 = MagicMock()
+        mock_loaded_2.id = "my-configured-model"
+        mock_loaded_2.status.get.return_value = "loaded"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_loaded_1, mock_loaded_2]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "my-configured-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "my-configured-model"
+
+    async def test_falls_back_to_first_loaded_when_config_not_loaded(self) -> None:
+        """When config model is not loaded, use first loaded model."""
+        mock_loaded_1 = MagicMock()
+        mock_loaded_1.id = "first-loaded-model"
+        mock_loaded_1.status.get.return_value = "loaded"
+
+        mock_loaded_2 = MagicMock()
+        mock_loaded_2.id = "second-loaded-model"
+        mock_loaded_2.status.get.return_value = "loaded"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_loaded_1, mock_loaded_2]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "not-loaded-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "first-loaded-model"
+
+    async def test_fallback_on_api_failure(self) -> None:
+        """When /models query fails, fall back to configured model."""
+        mock_client = MagicMock()
+        mock_client.models.list = AsyncMock(side_effect=Exception("Connection refused"))
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "fallback-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "fallback-model"
+
+    async def test_no_loaded_models_fallback(self) -> None:
+        """When no models are loaded, fall back to configured model."""
+        mock_unloaded = MagicMock()
+        mock_unloaded.id = "unloaded-model"
+        mock_unloaded.status.value = "unloaded"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_unloaded]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "fallback-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "fallback-model"
+
+    async def test_fresh_fetch_per_access(self) -> None:
+        """Each access to _async_get_model triggers a fresh server query."""
+        mock_loaded_model = MagicMock()
+        mock_loaded_model.id = "fresh-model"
+        mock_loaded_model.status.get.return_value = "loaded"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_loaded_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "config-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        first_call = await entity._async_get_model(None)
+        mock_client.models.list.reset_mock()
+        second_call = await entity._async_get_model(None)
+        assert first_call == second_call == "fresh-model"
+        mock_client.models.list.assert_called()
+
+    async def test_missing_entry_runtime_data_uses_configured(self) -> None:
+        """When entry has no runtime_data, fall back to configured model."""
+        entry = _StubEntry(runtime_data=None)
+        subentry = _StubSubentry(
+            {
+                "model": "config-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "config-model"
+
+    async def test_no_llamacpp_config_uses_configured(self) -> None:
+        """When llamacpp_config is missing, fall back to configured model."""
+        entry = MagicMock()
+        subentry = _StubSubentry(
+            {
+                "model": "config-model",
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(None) == "config-model"
+
+    async def test_modalities_empty_filters_nothing(self) -> None:
+        """No image attachments returns first loaded model regardless of architecture."""
+        mock_model = MagicMock()
+        mock_model.id = "text-only-model"
+        mock_model.status.get.return_value = "loaded"
+        mock_model.architecture = {"input_modalities": ["text"]}
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "config-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        assert await entity._async_get_model(_make_chat_log()) == "text-only-model"
+
+    async def test_modalities_match_uses_configured(self) -> None:
+        """Configured model is used when it is loaded and matches image modality."""
+        mock_model = MagicMock()
+        mock_model.id = "my-configured-model"
+        mock_model.status.get.return_value = "loaded"
+        mock_model.architecture = {"input_modalities": ["text", "image"]}
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "my-configured-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        chat_log = _make_chat_log([["image/png"]])
+        assert await entity._async_get_model(chat_log) == "my-configured-model"
+
+    async def test_modalities_mismatch_uses_first_matching_loaded(self) -> None:
+        """When config model doesn't match image modality, first matching loaded model is used."""
+        mock_config_model = MagicMock()
+        mock_config_model.id = "text-only-model"
+        mock_config_model.status.get.return_value = "loaded"
+        mock_config_model.architecture = {"input_modalities": ["text"]}
+
+        mock_matching_model = MagicMock()
+        mock_matching_model.id = "multimodal-model"
+        mock_matching_model.status.get.return_value = "loaded"
+        mock_matching_model.architecture = {"input_modalities": ["text", "image"]}
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_config_model, mock_matching_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "text-only-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        chat_log = _make_chat_log([["image/png"]])
+        assert await entity._async_get_model(chat_log) == "multimodal-model"
+
+    async def test_modalities_no_match_falls_back_to_configured(self) -> None:
+        """When no loaded model matches image modality, fall back to configured model."""
+        mock_model = MagicMock()
+        mock_model.id = "text-only-model"
+        mock_model.status.get.return_value = "loaded"
+        mock_model.architecture = {"input_modalities": ["text"]}
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "fallback-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        chat_log = _make_chat_log([["image/png"]])
+        assert await entity._async_get_model(chat_log) == "fallback-model"
+
+    async def test_modalities_model_without_architecture_matches(self) -> None:
+        """Models without architecture attribute are treated as matching all modalities."""
+        mock_model = MagicMock()
+        mock_model.id = "no-arch-model"
+        mock_model.status.get.return_value = "loaded"
+        del mock_model.architecture
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [mock_model]
+        mock_client.models.list = AsyncMock(return_value=mock_response)
+
+        entry = _StubEntry(runtime_data=mock_client)
+        subentry = _StubSubentry(
+            {
+                "model": "no-arch-model",
+                CONF_LLAMACPP_CONFIG: {
+                    CONF_LLAMACPP_USE_LOADED_MODEL: True,
+                },
+            }
+        )
+
+        class TestEntity(LlamaCppMixin, _StubBaseEntity):
+            pass
+
+        entity = TestEntity(entry, subentry)
+        chat_log = _make_chat_log([["image/png"]])
+        assert await entity._async_get_model(chat_log) == "no-arch-model"


### PR DESCRIPTION
Add `use loaded model` option for llama.cpp which treats the configured one as the preferred one but will use a suitable other model if its already loaded (to save on model swap time).

If probatio doesnt import, fallback to voluptuous for the time being.
- Will determine how ill handle this once 2026.9 final lands.